### PR TITLE
Add instances for Pos.Core.Fee

### DIFF
--- a/core/Pos/Binary/Cbor.hs
+++ b/core/Pos/Binary/Cbor.hs
@@ -1,4 +1,10 @@
--- Pos.Binary.Cbor
-{-# OPTIONS_GHC -F -pgmF autoexporter #-}
 {-# OPTIONS_GHC -Wno-unused-imports   #-}
 {-# OPTIONS_GHC -Wno-dodgy-exports    #-}
+
+module Pos.Binary.Cbor (
+  module CBOR
+  ) where
+
+import Pos.Binary.Cbor.Class as CBOR
+import Pos.Binary.Cbor.Serialization as CBOR
+import Pos.Binary.Cbor.TH as CBOR

--- a/core/Pos/Binary/Cbor/Class.hs
+++ b/core/Pos/Binary/Cbor/Class.hs
@@ -9,6 +9,7 @@ import           Codec.CBOR.Encoding
 import qualified Data.Binary                 as Binary
 import qualified Data.ByteString             as BS
 import qualified Data.ByteString.Lazy        as BS.Lazy
+import           Data.Fixed                  (Fixed(..), Nano)
 import qualified Data.HashMap.Strict         as HM
 import qualified Data.HashSet                as HS
 import qualified Data.Set                    as S
@@ -117,6 +118,10 @@ instance Bi Int where
 instance Bi Int32 where
     encode = encodeInt32
     decode = decodeInt32
+
+instance Bi Nano where
+    encode (MkFixed resolution) = encodeInteger resolution
+    decode = MkFixed <$> decodeInteger
 
 ----------------------------------------------------------------------------
 -- Tagged

--- a/core/Pos/Binary/Cbor/Test.hs
+++ b/core/Pos/Binary/Cbor/Test.hs
@@ -2,10 +2,12 @@
 {-# OPTIONS_GHC -ddump-splices #-}
 module Pos.Binary.Cbor.Test where
 
-import           Pos.Binary.Cbor.Class
-import           Pos.Binary.Cbor.TH
-import           Pos.Binary.Cbor.Serialization
+import           Pos.Binary.Cbor
 import           Universum
+import           Data.Fixed
+import           Test.QuickCheck hiding (Fixed)
+import           Pos.Core.Fee
+import           Pos.Binary.Core.Fee()
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
@@ -51,3 +53,11 @@ instance Bi T where
         0 ->         T1 . deserialize . BSL.fromStrict <$> decode
         1 -> uncurry T2 . deserialize . BSL.fromStrict <$> decode
         t -> Unknown t                                 <$> decode
+
+coeffRoundtripProperty :: Property
+coeffRoundtripProperty = forAll arbitrary $ \integer ->
+  let input = Coeff ((MkFixed integer) :: Nano)
+  in ((deserialize . serialize $ input) :: Coeff) === input
+
+roundtrips = do
+  quickCheck coeffRoundtripProperty


### PR DESCRIPTION
This first PR (yay!) adds some very basic instances for `Pos.Core.Fee` data types, together with some basic roundtrip tests (meant to be run via `ghci`, @arybczak knows the general context).

I have mostly predated piece of code here and there, but the general idea is that for simple, unary-constructor-data-types/newtypes I store directly the inner type, whereas the only notable exception is for the `TxFeePolicy`, where I have adopted a similar approach of the `Address` prototype, where we use a `Word8` tag to discriminate between different revisions.

I have also added some basic QC properties which hopefully should at least assess I'm not committing anything utterly silly.

Last but not least, I had to scrap the `autoexporter` pragma from the umbrella module `Pos.Binary.Cbor` as that was importing by default the `Test` module, creating an import cycle later down the pipeline.

Sorry for the multiple commits, but I had some minor hiccups signing my work.