### PR TITLE
Add instances for Pos.Core.Script & Pos.Core.Types

### DIFF
--- a/core/Pos/Binary/Cbor.hs
+++ b/core/Pos/Binary/Cbor.hs
@@ -2,9 +2,13 @@
 {-# OPTIONS_GHC -Wno-dodgy-exports    #-}
 
 module Pos.Binary.Cbor (
-  module CBOR
+    module CBOR
+  , decodeListLen
+  , encodeListLen
   ) where
 
 import Pos.Binary.Cbor.Class as CBOR
 import Pos.Binary.Cbor.Serialization as CBOR
 import Pos.Binary.Cbor.TH as CBOR
+import Codec.CBOR.Encoding (encodeListLen)
+import Codec.CBOR.Decoding (decodeListLen)

--- a/core/Pos/Binary/Cbor/Class.hs
+++ b/core/Pos/Binary/Cbor/Class.hs
@@ -2,6 +2,7 @@ module Pos.Binary.Cbor.Class
     ( Bi(..)
     , encodeBinary
     , decodeBinary
+    , enforceSize
     ) where
 
 import           Codec.CBOR.Decoding
@@ -35,6 +36,14 @@ decodeBinary = do
         Right (bs, _, res)
             | BS.Lazy.null bs -> pure res
             | otherwise       -> fail "decodeBinary: unconsumed input"
+
+-- | Enforces that the input size is the same as the decoded one, failing in case it's not.
+enforceSize :: String -> Int -> Decoder s ()
+enforceSize label requestedSize = do
+  actualSize <- decodeListLen
+  case actualSize == requestedSize of
+    True  -> return ()
+    False -> fail (label <> " failed the size check. Expected " <> show requestedSize <> ", found " <> show actualSize)
 
 ----------------------------------------
 

--- a/core/Pos/Binary/Cbor/Test.hs
+++ b/core/Pos/Binary/Cbor/Test.hs
@@ -74,20 +74,24 @@ soundInstanceProperty (Proxy :: Proxy a) = forAll (arbitrary :: Gen a) $ \input 
       isFlat       = hasValidFlatTerm input === True
   in itRoundtrips .&&. isFlat
 
+-- Override the `Args` to be a bit more exhaustive.
+qc :: Property -> IO ()
+qc = quickCheckWith (stdArgs { maxSuccess = 1000 })
+
 -- | A set of basic yet-useful roundtrips properties to be included as part
 -- of a bigger testsuite.
 soundInstancesTest :: IO ()
 soundInstancesTest = do
-  quickCheck (soundInstanceProperty @Coeff Proxy)
-  quickCheck (soundInstanceProperty @TxSizeLinear Proxy)
-  quickCheck (soundInstanceProperty @TxFeePolicy Proxy)
-  quickCheck (soundInstanceProperty @Script Proxy)
-  quickCheck (soundInstanceProperty @Timestamp Proxy)
-  quickCheck (soundInstanceProperty @EpochIndex Proxy)
-  quickCheck (soundInstanceProperty @Coin Proxy)
-  quickCheck (soundInstanceProperty @CoinPortion Proxy)
-  quickCheck (soundInstanceProperty @LocalSlotIndex Proxy)
-  quickCheck (soundInstanceProperty @SlotId Proxy)
-  quickCheck (soundInstanceProperty @EpochOrSlot Proxy)
-  quickCheck (soundInstanceProperty @SharedSeed Proxy)
-  quickCheck (soundInstanceProperty @ChainDifficulty Proxy)
+  qc (soundInstanceProperty @Coeff Proxy)
+  qc (soundInstanceProperty @TxSizeLinear Proxy)
+  qc (soundInstanceProperty @TxFeePolicy Proxy)
+  qc (soundInstanceProperty @Script Proxy)
+  qc (soundInstanceProperty @Timestamp Proxy)
+  qc (soundInstanceProperty @EpochIndex Proxy)
+  qc (soundInstanceProperty @Coin Proxy)
+  qc (soundInstanceProperty @CoinPortion Proxy)
+  qc (soundInstanceProperty @LocalSlotIndex Proxy)
+  qc (soundInstanceProperty @SlotId Proxy)
+  qc (soundInstanceProperty @EpochOrSlot Proxy)
+  qc (soundInstanceProperty @SharedSeed Proxy)
+  qc (soundInstanceProperty @ChainDifficulty Proxy)

--- a/core/Pos/Binary/Cbor/Test.hs
+++ b/core/Pos/Binary/Cbor/Test.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -ddump-splices #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Pos.Binary.Cbor.Test where
 
 import           Pos.Binary.Cbor
@@ -9,6 +10,14 @@ import           Test.QuickCheck
 import           Pos.Core.Fee
 import           Pos.Binary.Core.Fee()
 import           Pos.Core.Arbitrary()
+import           Pos.Binary.Core.Script()
+import           Pos.Core.Types (Script)
+import qualified PlutusCore.Program as Plutus
+import qualified PlutusCore.Term    as Plutus
+import qualified PlutusTypes.Type   as Plutus
+import qualified PlutusTypes.Type   as Plutus
+import qualified Utils.Vars         as Plutus
+import qualified Utils.ABT          as Plutus
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
@@ -68,3 +77,4 @@ roundtrips = do
   quickCheck (roundtripProperty @Coeff Proxy)
   quickCheck (roundtripProperty @TxSizeLinear Proxy)
   quickCheck (roundtripProperty @TxFeePolicy Proxy)
+  quickCheck (roundtripProperty @Script Proxy)

--- a/core/Pos/Binary/Cbor/Test.hs
+++ b/core/Pos/Binary/Cbor/Test.hs
@@ -76,3 +76,5 @@ roundtrips = do
   quickCheck (roundtripProperty @EpochIndex Proxy)
   quickCheck (roundtripProperty @Coin Proxy)
   quickCheck (roundtripProperty @CoinPortion Proxy)
+  quickCheck (roundtripProperty @LocalSlotIndex Proxy)
+  quickCheck (roundtripProperty @SlotId Proxy)

--- a/core/Pos/Binary/Cbor/Test.hs
+++ b/core/Pos/Binary/Cbor/Test.hs
@@ -11,7 +11,7 @@ import           Pos.Core.Fee
 import           Pos.Binary.Core.Fee()
 import           Pos.Core.Arbitrary()
 import           Pos.Binary.Core.Script()
-import           Pos.Core.Types (Script)
+import           Pos.Core.Types
 import qualified PlutusCore.Program as Plutus
 import qualified PlutusCore.Term    as Plutus
 import qualified PlutusTypes.Type   as Plutus
@@ -78,3 +78,5 @@ roundtrips = do
   quickCheck (roundtripProperty @TxSizeLinear Proxy)
   quickCheck (roundtripProperty @TxFeePolicy Proxy)
   quickCheck (roundtripProperty @Script Proxy)
+  quickCheck (roundtripProperty @Timestamp Proxy)
+  quickCheck (roundtripProperty @EpochIndex Proxy)

--- a/core/Pos/Binary/Cbor/Test.hs
+++ b/core/Pos/Binary/Cbor/Test.hs
@@ -78,3 +78,6 @@ roundtrips = do
   quickCheck (roundtripProperty @CoinPortion Proxy)
   quickCheck (roundtripProperty @LocalSlotIndex Proxy)
   quickCheck (roundtripProperty @SlotId Proxy)
+  quickCheck (roundtripProperty @EpochOrSlot Proxy)
+  quickCheck (roundtripProperty @SharedSeed Proxy)
+  quickCheck (roundtripProperty @ChainDifficulty Proxy)

--- a/core/Pos/Binary/Cbor/Test.hs
+++ b/core/Pos/Binary/Cbor/Test.hs
@@ -39,6 +39,20 @@ deriveSimpleBi ''User [
         Field [| sex       :: Bool   |]
     ]]
 
+data MyScript = MyScript
+    { version :: ScriptVersion -- ^ Version
+    , script  :: LByteString   -- ^ Serialized script
+    } deriving (Eq, Show, Generic, Typeable)
+
+instance Arbitrary MyScript where
+  arbitrary = MyScript <$> arbitrary <*> arbitrary
+
+deriveSimpleBi ''MyScript [
+    Cons 'MyScript [
+        Field [| version :: ScriptVersion |],
+        Field [| script  :: LByteString   |]
+    ]]
+
 u1 :: User
 u1 = deserialize $ serialize $ Login "asd" 34
 
@@ -82,6 +96,7 @@ qc = quickCheckWith (stdArgs { maxSuccess = 1000 })
 -- of a bigger testsuite.
 soundInstancesTest :: IO ()
 soundInstancesTest = do
+  qc (soundInstanceProperty @MyScript Proxy)
   qc (soundInstanceProperty @Coeff Proxy)
   qc (soundInstanceProperty @TxSizeLinear Proxy)
   qc (soundInstanceProperty @TxFeePolicy Proxy)

--- a/core/Pos/Binary/Cbor/Test.hs
+++ b/core/Pos/Binary/Cbor/Test.hs
@@ -12,12 +12,6 @@ import           Pos.Binary.Core.Fee()
 import           Pos.Core.Arbitrary()
 import           Pos.Binary.Core.Script()
 import           Pos.Core.Types
-import qualified PlutusCore.Program as Plutus
-import qualified PlutusCore.Term    as Plutus
-import qualified PlutusTypes.Type   as Plutus
-import qualified PlutusTypes.Type   as Plutus
-import qualified Utils.Vars         as Plutus
-import qualified Utils.ABT          as Plutus
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
@@ -80,3 +74,5 @@ roundtrips = do
   quickCheck (roundtripProperty @Script Proxy)
   quickCheck (roundtripProperty @Timestamp Proxy)
   quickCheck (roundtripProperty @EpochIndex Proxy)
+  quickCheck (roundtripProperty @Coin Proxy)
+  quickCheck (roundtripProperty @CoinPortion Proxy)

--- a/core/Pos/Binary/Core/Script.hs
+++ b/core/Pos/Binary/Core/Script.hs
@@ -61,14 +61,8 @@ instance Bi Script where
         putField (UnsignedVarInt . scrVersion) <>
         putField scrScript
 
---Cbor.deriveSimpleBi ''Script [
---    Cbor.Cons 'Script [
---        Cbor.Field [| scrVersion :: ScriptVersion |],
---        Cbor.Field [| scrScript  :: LByteString   |]
---    ]]
-
-instance Cbor.Bi Script where
-  encode (Script vr scr) = Cbor.encodeListLen 2 <> Cbor.encode vr <> Cbor.encode scr
-  decode = do
-    Cbor.enforceSize "Script" 2
-    Script <$> Cbor.decode <*> Cbor.decode
+Cbor.deriveSimpleBi ''Script [
+    Cbor.Cons 'Script [
+        Cbor.Field [| scrVersion :: ScriptVersion |],
+        Cbor.Field [| scrScript  :: LByteString   |]
+    ]]

--- a/core/Pos/Binary/Core/Script.hs
+++ b/core/Pos/Binary/Core/Script.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TemplateHaskell #-}
 module Pos.Binary.Core.Script () where
 
 import           Universum
@@ -8,8 +9,24 @@ import qualified PlutusCore.Term    as PLCore
 
 import           Pos.Binary.Class   (Bi (..), UnsignedVarInt (..), label, labelP, labelS,
                                      putField)
+import qualified Pos.Binary.Cbor     as Cbor
+import qualified Codec.CBOR.Encoding as Cbor.Encoding
+import qualified Codec.CBOR.Decoding as Cbor.Decoding
 import           Pos.Core.Script    ()
-import           Pos.Core.Types     (Script (..))
+import           Pos.Core.Types     (Script (..), ScriptVersion)
+
+
+
+-- Derive `Cbor.Bi` instances by piggybacking
+-- on Store instances, in preparation for a proper
+-- rewrite down the line.
+storeEncode :: Store.Store a => a -> Cbor.Encoding.Encoding
+storeEncode = Cbor.encode @ByteString . Store.encode
+
+storeDecode :: Store.Store a => Cbor.Decoding.Decoder s a
+storeDecode = do
+    storeBs <- Cbor.decode @ByteString
+    either (fail . show) return (Store.decode storeBs)
 
 instance Bi PLCore.Term where
     size = Store.size
@@ -19,6 +36,10 @@ instance Bi PLCore.Term where
     put = labelP "PLCore.Term" . Store.poke
     {-# INLINE put #-}
 
+instance Cbor.Bi PLCore.Term where
+  encode = storeEncode
+  decode = storeDecode
+
 instance Bi PLCore.Program where
     size = Store.size
     {-# INLINE size #-}
@@ -26,6 +47,10 @@ instance Bi PLCore.Program where
     {-# INLINE get #-}
     put = labelP "PLCore.Program" . Store.poke
     {-# INLINE put #-}
+
+instance Cbor.Bi PLCore.Program where
+  encode = storeEncode
+  decode = storeDecode
 
 instance Bi Script where
     get = label "Script" $ do
@@ -35,3 +60,9 @@ instance Bi Script where
     sizeNPut = labelS "Script" $
         putField (UnsignedVarInt . scrVersion) <>
         putField scrScript
+
+Cbor.deriveSimpleBi ''Script [
+    Cbor.Cons 'Script [
+        Cbor.Field [| scrVersion :: ScriptVersion |],
+        Cbor.Field [| scrScript  :: LByteString   |]
+    ]]

--- a/core/Pos/Binary/Core/Script.hs
+++ b/core/Pos/Binary/Core/Script.hs
@@ -61,8 +61,14 @@ instance Bi Script where
         putField (UnsignedVarInt . scrVersion) <>
         putField scrScript
 
-Cbor.deriveSimpleBi ''Script [
-    Cbor.Cons 'Script [
-        Cbor.Field [| scrVersion :: ScriptVersion |],
-        Cbor.Field [| scrScript  :: LByteString   |]
-    ]]
+--Cbor.deriveSimpleBi ''Script [
+--    Cbor.Cons 'Script [
+--        Cbor.Field [| scrVersion :: ScriptVersion |],
+--        Cbor.Field [| scrScript  :: LByteString   |]
+--    ]]
+
+instance Cbor.Bi Script where
+  encode (Script vr scr) = Cbor.encodeListLen 2 <> Cbor.encode vr <> Cbor.encode scr
+  decode = do
+    Cbor.enforceSize "Script" 2
+    Script <$> Cbor.decode <*> Cbor.decode

--- a/core/Pos/Binary/Core/Types.hs
+++ b/core/Pos/Binary/Core/Types.hs
@@ -95,6 +95,10 @@ instance Bi T.EpochOrSlot where
     sizeNPut = labelS "EpochOrSlot" $ putField T.unEpochOrSlot
     get = label "EpochOrSlot" $ T.EpochOrSlot <$> get
 
+instance Cbor.Bi T.EpochOrSlot where
+  encode (T.EpochOrSlot e) = Cbor.encode e
+  decode = T.EpochOrSlot <$> Cbor.decode @(Either T.EpochIndex T.SlotId)
+
 -- serialized as vector of TxInWitness
 --instance Bi T.TxWitness where
 
@@ -103,10 +107,19 @@ deriveSimpleBi ''T.SharedSeed [
         Field [| T.getSharedSeed :: ByteString |]
     ]]
 
+Cbor.deriveSimpleBi ''T.SharedSeed [
+    Cbor.Cons 'T.SharedSeed [
+        Cbor.Field [| T.getSharedSeed :: ByteString |]
+    ]]
+
 instance Bi T.ChainDifficulty where
     sizeNPut = labelS "ChainDifficulty" $ putField (UnsignedVarInt . T.getChainDifficulty)
     get = label "ChainDifficulty" $
           T.ChainDifficulty . getUnsignedVarInt <$> get
+
+instance Cbor.Bi T.ChainDifficulty where
+  encode (T.ChainDifficulty word64) = Cbor.encode word64
+  decode = T.ChainDifficulty <$> Cbor.decode @Word64
 
 deriveSimpleBi ''T.BlockVersionData [
     Cons 'T.BlockVersionData [
@@ -123,4 +136,21 @@ deriveSimpleBi ''T.BlockVersionData [
         Field [| T.bvdUpdateImplicit    :: T.FlatSlotId    |],
         Field [| T.bvdUpdateSoftforkThd :: T.CoinPortion   |],
         Field [| T.bvdTxFeePolicy       :: T.TxFeePolicy   |]
+    ]]
+
+Cbor.deriveSimpleBi ''T.BlockVersionData [
+    Cbor.Cons 'T.BlockVersionData [
+        Cbor.Field [| T.bvdScriptVersion     :: T.ScriptVersion |],
+        Cbor.Field [| T.bvdSlotDuration      :: Millisecond     |],
+        Cbor.Field [| T.bvdMaxBlockSize      :: Byte            |],
+        Cbor.Field [| T.bvdMaxHeaderSize     :: Byte            |],
+        Cbor.Field [| T.bvdMaxTxSize         :: Byte            |],
+        Cbor.Field [| T.bvdMaxProposalSize   :: Byte            |],
+        Cbor.Field [| T.bvdMpcThd            :: T.CoinPortion   |],
+        Cbor.Field [| T.bvdHeavyDelThd       :: T.CoinPortion   |],
+        Cbor.Field [| T.bvdUpdateVoteThd     :: T.CoinPortion   |],
+        Cbor.Field [| T.bvdUpdateProposalThd :: T.CoinPortion   |],
+        Cbor.Field [| T.bvdUpdateImplicit    :: T.FlatSlotId    |],
+        Cbor.Field [| T.bvdUpdateSoftforkThd :: T.CoinPortion   |],
+        Cbor.Field [| T.bvdTxFeePolicy       :: T.TxFeePolicy   |]
     ]]

--- a/core/Pos/Binary/Core/Types.hs
+++ b/core/Pos/Binary/Core/Types.hs
@@ -12,6 +12,9 @@ import qualified Pos.Binary.Core.Coin       as BinCoin
 import           Pos.Binary.Core.Fee        ()
 import           Pos.Binary.Core.Script     ()
 import           Pos.Binary.Core.Version    ()
+import qualified Pos.Binary.Cbor            as Cbor
+import qualified Codec.CBOR.Encoding        as Cbor.Encoding
+import qualified Codec.CBOR.Decoding        as Cbor.Decoding
 import qualified Pos.Core.Fee               as T
 import qualified Pos.Core.Types             as T
 import qualified Pos.Data.Attributes        as A
@@ -24,9 +27,17 @@ instance Bi T.Timestamp where
     sizeNPut = labelS "Timestamp" $ putField toInteger
     get = label "Timestamp" $ fromInteger <$> get
 
+instance Cbor.Bi T.Timestamp where
+  encode (T.Timestamp ms) = Cbor.encode . toInteger $ ms
+  decode = T.Timestamp . fromIntegral <$> Cbor.decode @Integer
+
 instance Bi T.EpochIndex where
     sizeNPut = labelS "EpochIndex" $ putField (UnsignedVarInt . T.getEpochIndex)
     get = label "EpochIndex" $ T.EpochIndex . getUnsignedVarInt <$> get
+
+instance Cbor.Bi T.EpochIndex where
+  encode (T.EpochIndex epoch) = Cbor.Encoding.encodeWord64 epoch
+  decode = T.EpochIndex <$> Cbor.Decoding.decodeWord64
 
 instance Bi (A.Attributes ()) where
     size = VarSize $ A.sizeAttributes (\() -> [])


### PR DESCRIPTION
@arybczak This PR adds `Cbor.Bi` instances for `Pos.Core.Script` and `Pos.Core.Types`, in the current flavour:

* For `Pos.Core.Script` we are piggybacking on the `Store` instances whenever we can, in accordance to the migration plan outlined;

* For `Pos.Core.Types` we are adding an equivalent `Cbor.Bi` instance for each plain `Bi` in scope. As discussed with Andrzej, I have skipped the problematic `Attributes ()` instance;

* Basic roundtrip properties are provided, with the notable exception of the Plutus types (I started to derive `Arbitrary` instances for the AST but it proved to be too much of a time sink, as well as not being feasible due to the fact it's essentially a free monad) and the `BlockVersionData`. The latter doesn't have an `Arbitrary` instance, although (I guess) in principle that can be done.

* In general, I have tried to favour the `Cbor.encode` and `Cbor.decode` variants to the more type-specific, CBOR ones, as the rationale is that - unless we don't have extensive code coverage - changing the inner type of a `newtype`, for example, would make the serialisation fail silently, whereas using the generic versions the compiler is free to pick what's best at compile time. Let me know if you guys think this is ill-founded reasoning.

EDIT: Some tests are now failing as we realised flat term encoding needs to be tested and ensured as well, which wasn't the case for instances I wrote yesterday 🙈  

cc @dcoutts