### PR TITLE
More instances and fix faulty `TxFeePolicy` instance

### DIFF
--- a/core/Pos/Binary/Cbor/Class.hs
+++ b/core/Pos/Binary/Cbor/Class.hs
@@ -3,6 +3,7 @@ module Pos.Binary.Cbor.Class
     , encodeBinary
     , decodeBinary
     , enforceSize
+    , matchSize
     ) where
 
 import           Codec.CBOR.Decoding
@@ -39,8 +40,11 @@ decodeBinary = do
 
 -- | Enforces that the input size is the same as the decoded one, failing in case it's not.
 enforceSize :: String -> Int -> Decoder s ()
-enforceSize label requestedSize = do
-  actualSize <- decodeListLen
+enforceSize label requestedSize = decodeListLen >>= matchSize requestedSize label
+
+-- | Compare two sizes, failing if they are not equal.
+matchSize :: Int -> String -> Int -> Decoder s ()
+matchSize requestedSize label actualSize = do
   case actualSize == requestedSize of
     True  -> return ()
     False -> fail (label <> " failed the size check. Expected " <> show requestedSize <> ", found " <> show actualSize)

--- a/core/Pos/Binary/Cbor/Test.hs
+++ b/core/Pos/Binary/Cbor/Test.hs
@@ -13,6 +13,7 @@ import           Pos.Binary.Core.Fee()
 import           Pos.Core.Arbitrary()
 import           Pos.Binary.Core.Script()
 import           Pos.Core.Types
+import           Pos.Core.Genesis.Types
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
@@ -110,3 +111,4 @@ soundInstancesTest = do
   qc (soundInstanceProperty @EpochOrSlot Proxy)
   qc (soundInstanceProperty @SharedSeed Proxy)
   qc (soundInstanceProperty @ChainDifficulty Proxy)
+  qc (soundInstanceProperty @StakeDistribution Proxy)

--- a/core/Pos/Binary/Cbor/Test.hs
+++ b/core/Pos/Binary/Cbor/Test.hs
@@ -134,3 +134,6 @@ soundInstancesTest = do
   qc (soundInstanceProperty @SharedSeed Proxy)
   qc (soundInstanceProperty @ChainDifficulty Proxy)
   qc (soundInstanceProperty @StakeDistribution Proxy)
+  qc (soundInstanceProperty @ApplicationName Proxy)
+  qc (soundInstanceProperty @SoftwareVersion Proxy)
+  qc (soundInstanceProperty @BlockVersion Proxy)

--- a/core/Pos/Binary/Core/Address.hs
+++ b/core/Pos/Binary/Core/Address.hs
@@ -10,6 +10,7 @@ import           Pos.Binary.Class    (Bi (..), Peek, Poke, PokeWithSize, Size (.
                                       getSmallWithLength, getWord8, label, labelS,
                                       putBytesS, putField, putS, putSmallWithLengthS,
                                       putWord8S)
+import qualified Pos.Binary.Cbor     as Cbor
 import           Pos.Binary.Crypto   ()
 import           Pos.Core.Types      (AddrPkAttrs (..), Address (..))
 import           Pos.Data.Attributes (getAttributes, putAttributesS)
@@ -100,3 +101,8 @@ instance Bi Address where
        if checksum /= crc32 addr
            then fail "Address has invalid checksum!"
            else return addr
+
+-- Just a stub as @arybczak is working on it.
+instance Cbor.Bi Address where
+  encode = error "Address encode: unimplemented"
+  decode = fail  "Address decode: unimplemented"

--- a/core/Pos/Binary/Core/Fee.hs
+++ b/core/Pos/Binary/Core/Fee.hs
@@ -60,11 +60,13 @@ instance Bi TxFeePolicy where
 
 instance Cbor.Bi TxFeePolicy where
   encode policy = case policy of
-    TxFeePolicyTxSizeLinear txSizeLinear -> Cbor.encodeListLen 2 <> Cbor.encode (0 :: Word8) <> Cbor.encode txSizeLinear
-    TxFeePolicyUnknown word8 bs          -> Cbor.encodeListLen 2 <> Cbor.encode word8        <> Cbor.encode bs
+    TxFeePolicyTxSizeLinear txSizeLinear -> Cbor.encodeListLen 2 <> Cbor.encode (0 :: Word8)
+                                                                 <> Cbor.encode (Cbor.serialize' txSizeLinear)
+    TxFeePolicyUnknown word8 bs          -> Cbor.encodeListLen 2 <> Cbor.encode word8
+                                                                 <> Cbor.encode bs
   decode = do
     Cbor.enforceSize "TxFeePolicy" 2
     tag <- Cbor.decode @Word8
     case tag of
-      0 -> TxFeePolicyTxSizeLinear <$> Cbor.decode @TxSizeLinear
-      _ -> TxFeePolicyUnknown tag  <$> Cbor.decode
+      0 -> TxFeePolicyTxSizeLinear . Cbor.deserialize' <$> Cbor.decode
+      _ -> TxFeePolicyUnknown tag                      <$> Cbor.decode

--- a/core/Pos/Binary/Core/Genesis.hs
+++ b/core/Pos/Binary/Core/Genesis.hs
@@ -8,6 +8,7 @@ import           Pos.Binary.Class        (Bi (..), Peek, PokeWithSize,
                                           UnsignedVarInt (..), convertToSizeNPut,
                                           getWord8, label, labelS, putField, putS,
                                           putWord8S)
+import qualified Pos.Binary.Cbor         as Cbor
 import           Pos.Binary.Core.Address ()
 import           Pos.Binary.Core.Types   ()
 import           Pos.Core.Address        ()
@@ -38,6 +39,29 @@ instance Bi StakeDistribution where
             putUVI n <> putS ps
         f (ExponentialStakes n)      = putWord8S 3 <> putUVI n
         f (CustomStakes coins)       = putWord8S 4 <> putS coins
+
+instance Cbor.Bi StakeDistribution where
+  encode input = case input of
+    FlatStakes w c             -> Cbor.encodeListLen 3 <> Cbor.encode (0 :: Word8) <> Cbor.encode w <> Cbor.encode c
+    BitcoinStakes w c          -> Cbor.encodeListLen 3 <> Cbor.encode (1 :: Word8) <> Cbor.encode w <> Cbor.encode c
+    RichPoorStakes w1 c1 w2 c2 -> Cbor.encodeListLen 5 <> Cbor.encode (2 :: Word8)
+                                                       <> Cbor.encode w1
+                                                       <> Cbor.encode c1
+                                                       <> Cbor.encode w2
+                                                       <> Cbor.encode c2
+    ExponentialStakes w        -> Cbor.encodeListLen 2 <> Cbor.encode (3 :: Word8) <> Cbor.encode w
+    CustomStakes c             -> Cbor.encodeListLen 2 <> Cbor.encode (4 :: Word8) <> Cbor.encode c
+  decode = do
+    _ <- Cbor.decodeListLen
+    tag <- Cbor.decode @Word8
+    case tag of
+      0 -> FlatStakes        <$> Cbor.decode <*> Cbor.decode
+      1 -> BitcoinStakes     <$> Cbor.decode <*> Cbor.decode
+      2 -> RichPoorStakes    <$> Cbor.decode <*> Cbor.decode <*> Cbor.decode <*> Cbor.decode
+      3 -> ExponentialStakes <$> Cbor.decode
+      4 -> CustomStakes      <$> Cbor.decode
+      _ -> fail "Pos.Binary.Genesis: StakeDistribution: invalid tag"
+
 
 instance Bi GenesisCoreData where
     get = label "GenesisCoreData" $ do

--- a/core/Pos/Binary/Core/Types.hs
+++ b/core/Pos/Binary/Core/Types.hs
@@ -43,6 +43,11 @@ instance Bi (A.Attributes ()) where
         A.getAttributes (\_ () -> Nothing) (Just (128 * 1024 * 1024)) ()
     put = labelP "Attributes" . A.putAttributes (\() -> [])
 
+-- Stubbed in preparation to refactoring to better fit it into the CBOR model.
+instance Cbor.Bi (A.Attributes ()) where
+  encode = error "Attributes () encode: Unimplemented."
+  decode = fail  "Attributes () decode: Unimplemented."
+
 instance Bi T.Coin where
     size = VarSize BinCoin.size
     put = labelP "Coin" . mapM_ putWord8 . BinCoin.encode

--- a/core/Pos/Binary/Core/Version.hs
+++ b/core/Pos/Binary/Core/Version.hs
@@ -8,6 +8,7 @@ import           Pos.Binary.Class (Bi (..), Cons (..), Field (..), convertSize,
                                    deriveSimpleBi, getAsciiString1b, label, labelP,
                                    putAsciiString1b, sizeAsciiString1b)
 import qualified Pos.Core.Types   as V
+import qualified Pos.Binary.Cbor  as Cbor
 
 instance Bi V.ApplicationName where
     size = convertSize (toString . V.getApplicationName) sizeAsciiString1b
@@ -16,10 +17,24 @@ instance Bi V.ApplicationName where
     get = label "ApplicationName" $ V.mkApplicationName . toText
             =<< getAsciiString1b "SystemTag" V.applicationNameMaxLength
 
+instance Cbor.Bi V.ApplicationName where
+  encode appName = Cbor.encode (V.getApplicationName appName)
+  decode = do
+    appName <- Cbor.decode
+    case V.mkApplicationName appName of
+      Left e  -> fail e
+      Right a -> pure a
+
 deriveSimpleBi ''V.SoftwareVersion [
     Cons 'V.SoftwareVersion [
         Field [| V.svAppName :: V.ApplicationName    |],
         Field [| V.svNumber  :: V.NumSoftwareVersion |]
+    ]]
+
+Cbor.deriveSimpleBi ''V.SoftwareVersion [
+    Cbor.Cons 'V.SoftwareVersion [
+        Cbor.Field [| V.svAppName :: V.ApplicationName    |],
+        Cbor.Field [| V.svNumber  :: V.NumSoftwareVersion |]
     ]]
 
 deriveSimpleBi ''V.BlockVersion [
@@ -27,4 +42,11 @@ deriveSimpleBi ''V.BlockVersion [
         Field [| V.bvMajor :: Word16 |],
         Field [| V.bvMinor :: Word16 |],
         Field [| V.bvAlt   :: Word8  |]
+    ]]
+
+Cbor.deriveSimpleBi ''V.BlockVersion [
+    Cbor.Cons 'V.BlockVersion [
+        Cbor.Field [| V.bvMajor :: Word16 |],
+        Cbor.Field [| V.bvMinor :: Word16 |],
+        Cbor.Field [| V.bvAlt   :: Word8  |]
     ]]

--- a/core/Pos/Binary/Crypto.hs
+++ b/core/Pos/Binary/Crypto.hs
@@ -148,6 +148,8 @@ instance Cbor.Bi SecretSharingExtra where
     encode = error "encode SecretSharingExtra"
     decode = error "decode SecretSharingExtra"
 
+deriving instance Cbor.Bi (AsBinary SecretSharingExtra)
+
 ----------------------------------------------------------------------------
 -- SecretSharing AsBinary
 ----------------------------------------------------------------------------

--- a/core/Pos/Binary/Merkle.hs
+++ b/core/Pos/Binary/Merkle.hs
@@ -5,8 +5,9 @@ module Pos.Binary.Merkle () where
 import           Universum
 
 import           Pos.Binary.Class   (Bi (..), Raw, label, putField)
+import qualified Pos.Binary.Cbor    as Cbor
 import           Pos.Crypto.Hashing (Hash)
-import           Pos.Merkle         (MerkleRoot (..), MerkleTree (..), mkMerkleTree)
+import           Pos.Merkle         (MerkleRoot (..), MerkleTree (..), mkMerkleTree, mkMerkleTreeCbor)
 
 -- This instance is both faster and more space-efficient (as confirmed by a
 -- benchmark). Hashing turns out to be faster than decoding extra data.
@@ -14,6 +15,14 @@ instance (Bi a, Bi (Hash Raw)) => Bi (MerkleTree a) where
     sizeNPut = putField toList
     get = label "MerkleTree" $ mkMerkleTree <$> get
 
+instance (Cbor.Bi a, Cbor.Bi (Hash Raw)) => Cbor.Bi (MerkleTree a) where
+  encode = Cbor.encode . toList
+  decode = mkMerkleTreeCbor <$> Cbor.decode
+
 instance (Bi a, Bi (Hash Raw)) => Bi (MerkleRoot a) where
     sizeNPut = putField getMerkleRoot
     get = label "MerkleRoot" $ MerkleRoot <$> get
+
+instance (Cbor.Bi a, Cbor.Bi (Hash Raw)) => Cbor.Bi (MerkleRoot a) where
+  encode = Cbor.encode . getMerkleRoot
+  decode = MerkleRoot <$> Cbor.decode

--- a/godtossing/Pos/Binary/GodTossing/Core.hs
+++ b/godtossing/Pos/Binary/GodTossing/Core.hs
@@ -7,6 +7,7 @@ module Pos.Binary.GodTossing.Core
 import qualified Data.HashMap.Strict           as HM
 import           Universum
 
+import qualified Pos.Binary.Cbor               as Cbor
 import           Pos.Binary.Class              (Bi (..), PokeWithSize, convertToSizeNPut,
                                                 getWord8, label, labelS, putField, putS,
                                                 putWord8S)
@@ -30,9 +31,21 @@ instance Bi Commitment where
         commProof <- get
         return Commitment {..}
 
+instance Cbor.Bi Commitment where
+  encode Commitment{..} = Cbor.encodeListLen 3 <> Cbor.encode commExtra
+                                               <> Cbor.encode commProof
+                                               <> Cbor.encode commShares
+  decode = do
+    Cbor.enforceSize "Commitment" 3
+    Commitment <$> Cbor.decode <*> Cbor.decode <*> Cbor.decode
+
 instance Bi CommitmentsMap where
     sizeNPut = labelS "CommitmentsMap" $ putField (toList . getCommitmentsMap)
     get = label "CommitmentsMap" $ mkCommitmentsMap <$> get
+
+instance Cbor.Bi CommitmentsMap where
+  encode = Cbor.encode . HM.elems . getCommitmentsMap
+  decode = mkCommitmentsMap <$> Cbor.decode
 
 instance Bi VssCertificate where
     sizeNPut = labelS "VssCertificate" $
@@ -43,9 +56,28 @@ instance Bi VssCertificate where
     get = label "VssCertificate" $
         join $ liftM4 recreateVssCertificate get get get get
 
+instance Cbor.Bi VssCertificate where
+  encode vssCert = Cbor.encodeListLen 4 <> Cbor.encode (vcVssKey vssCert)
+                                        <> Cbor.encode (vcExpiryEpoch vssCert)
+                                        <> Cbor.encode (vcSignature vssCert)
+                                        <> Cbor.encode (vcSigningKey vssCert)
+  decode = do
+    Cbor.enforceSize "VssCertificate" 4
+    key <- Cbor.decode
+    epo <- Cbor.decode
+    sig <- Cbor.decode
+    sky <- Cbor.decode
+    case recreateVssCertificate key epo sig sky of
+      Left e  -> fail e
+      Right v -> pure v
+
 instance Bi Opening where
     sizeNPut = labelS "Opening" $ putField getOpening
     get = label "Opening" $ Opening <$> get
+
+instance Cbor.Bi Opening where
+  encode = Cbor.encode . getOpening
+  decode = Opening <$> Cbor.decode
 
 instance Bi GtPayload where
     sizeNPut = labelS "GtPayload" $ convertToSizeNPut toBi
@@ -71,6 +103,26 @@ instance Bi GtPayload where
             getVssCerts = HM.fromList . map toCertPair <$> get
             toCertPair vc = (addressHash $ vcSigningKey vc, vc)
 
+instance Cbor.Bi GtPayload where
+  encode input = case input of
+    CommitmentsPayload  cmap vss -> Cbor.encodeListLen 3 <> Cbor.encode (0 :: Word8)
+                                                         <> Cbor.encode cmap <> Cbor.encode vss
+    OpeningsPayload     omap vss -> Cbor.encodeListLen 3 <> Cbor.encode (1 :: Word8)
+                                                         <> Cbor.encode omap <> Cbor.encode vss
+    SharesPayload       smap vss -> Cbor.encodeListLen 3 <> Cbor.encode (2 :: Word8)
+                                                         <> Cbor.encode smap <> Cbor.encode vss
+    CertificatesPayload vss      -> Cbor.encodeListLen 2 <> Cbor.encode (3 :: Word8)
+                                                         <> Cbor.encode vss
+  decode = do
+    _   <- Cbor.decodeListLen
+    tag <- Cbor.decode @Word8
+    case tag of
+      0 -> CommitmentsPayload  <$> Cbor.decode <*> Cbor.decode
+      1 -> OpeningsPayload     <$> Cbor.decode <*> Cbor.decode
+      2 -> SharesPayload       <$> Cbor.decode <*> Cbor.decode
+      3 -> CertificatesPayload <$> Cbor.decode
+      _ -> fail ("get@GtPayload: invalid tag: " ++ show tag)
+
 instance Bi GtProof where
     sizeNPut = labelS "GtProof" $ convertToSizeNPut toBi
       where
@@ -87,3 +139,23 @@ instance Bi GtProof where
             2 -> liftM2 SharesProof get get
             3 -> CertificatesProof <$> get
             tag -> fail ("get@GtProof: invalid tag: " ++ show tag)
+
+instance Cbor.Bi GtProof where
+  encode input = case input of
+    CommitmentsProof  cmap vss -> Cbor.encodeListLen 3 <> Cbor.encode (0 :: Word8)
+                                                       <> Cbor.encode cmap <> Cbor.encode vss
+    OpeningsProof     omap vss -> Cbor.encodeListLen 3 <> Cbor.encode (1 :: Word8)
+                                                       <> Cbor.encode omap <> Cbor.encode vss
+    SharesProof       smap vss -> Cbor.encodeListLen 3 <> Cbor.encode (2 :: Word8)
+                                                       <> Cbor.encode smap <> Cbor.encode vss
+    CertificatesProof vss      -> Cbor.encodeListLen 2 <> Cbor.encode (3 :: Word8)
+                                                       <> Cbor.encode vss
+  decode = do
+    _   <- Cbor.decodeListLen
+    tag <- Cbor.decode @Word8
+    case tag of
+      0 -> CommitmentsProof  <$> Cbor.decode <*> Cbor.decode
+      1 -> OpeningsProof     <$> Cbor.decode <*> Cbor.decode
+      2 -> SharesProof       <$> Cbor.decode <*> Cbor.decode
+      3 -> CertificatesProof <$> Cbor.decode
+      _ -> fail ("get@GtProof: invalid tag: " ++ show tag)

--- a/godtossing/Pos/Binary/GodTossing/Relay.hs
+++ b/godtossing/Pos/Binary/GodTossing/Relay.hs
@@ -7,11 +7,16 @@ import           Universum
 import           Pos.Binary.Class              (Bi (..), label, labelS, putField)
 import           Pos.Communication.Types.Relay (DataMsg (..))
 import qualified Pos.Ssc.GodTossing.Types      as T
+import qualified Pos.Binary.Cbor               as Cbor
 
 instance Bi (DataMsg T.MCCommitment) where
     sizeNPut = labelS "DataMsg MCCommitment" $
         putField (\(DataMsg (T.MCCommitment signedComm)) -> signedComm)
     get = label "DataMsg MCCommitment" $ fmap DataMsg $ T.MCCommitment <$> get
+
+instance Cbor.Bi (DataMsg T.MCCommitment) where
+  encode (DataMsg (T.MCCommitment signedComm)) = Cbor.encode signedComm
+  decode = DataMsg . T.MCCommitment <$> Cbor.decode
 
 instance Bi (DataMsg T.MCOpening) where
     sizeNPut = labelS "DataMsg MCOpening" $
@@ -19,13 +24,29 @@ instance Bi (DataMsg T.MCOpening) where
         putField (\(DataMsg (T.MCOpening _ op)) -> op)
     get =  label "DataMsg MCOpening" $ DataMsg <$> liftM2 T.MCOpening get get
 
+instance Cbor.Bi (DataMsg T.MCOpening) where
+  encode (DataMsg (T.MCOpening sId opening)) = Cbor.encodeListLen 2 <> Cbor.encode sId <> Cbor.encode opening
+  decode = do
+    Cbor.enforceSize "DataMsg T.MCOpening" 2
+    DataMsg <$> (T.MCOpening <$> Cbor.decode <*> Cbor.decode)
+
 instance Bi (DataMsg T.MCShares) where
     sizeNPut = labelS "DataMsg MCShares" $
         putField (\(DataMsg (T.MCShares st _)) -> st) <>
         putField (\(DataMsg (T.MCShares _ im)) -> im)
     get = label "DataMsg MCShares" $ DataMsg <$> liftM2 T.MCShares get get
 
+instance Cbor.Bi (DataMsg T.MCShares) where
+  encode (DataMsg (T.MCShares sId innerMap)) = Cbor.encodeListLen 2 <> Cbor.encode sId <> Cbor.encode innerMap
+  decode = do
+    Cbor.enforceSize "DataMsg T.MCShares" 2
+    DataMsg <$> (T.MCShares <$> Cbor.decode <*> Cbor.decode)
+
 instance Bi (DataMsg T.MCVssCertificate) where
     sizeNPut = labelS "DataMsg MCVssCertificate" $
         putField $ \(DataMsg (T.MCVssCertificate vssCert)) -> vssCert
     get = label "DataMsg MCVssCertificate" $ fmap DataMsg $ T.MCVssCertificate <$> get
+
+instance Cbor.Bi (DataMsg T.MCVssCertificate) where
+  encode (DataMsg (T.MCVssCertificate vss)) = Cbor.encode vss
+  decode = DataMsg . T.MCVssCertificate <$> Cbor.decode

--- a/infra/Pos/Binary/Infra/DHTModel.hs
+++ b/infra/Pos/Binary/Infra/DHTModel.hs
@@ -10,6 +10,7 @@ import qualified Data.Store.Internal         as Store
 import           Network.Kademlia.HashNodeId (HashId (..))
 
 import           Pos.Binary.Class            (Bi (..), Size (..), getSize, label, labelP)
+import qualified Pos.Binary.Cbor             as Cbor
 import           Pos.DHT.Model.Types         (DHTData (..), DHTKey (..))
 
 instance Bi DHTKey where
@@ -18,10 +19,18 @@ instance Bi DHTKey where
     put (DHTKey (HashId bs)) = labelP "DHTKey" $ put bs
     get = label "DHTKey" $ DHTKey . HashId <$> get
 
+instance Cbor.Bi DHTKey where
+  encode (DHTKey (HashId bs)) = Cbor.encode bs
+  decode = DHTKey . HashId <$> Cbor.decode
+
 instance Bi DHTData where
     size = ConstSize 0
     put (DHTData ()) = labelP "DHTData" $ pure ()
     get = label "DHTData" $ pure $ DHTData ()
+
+instance Cbor.Bi DHTData where
+  encode (DHTData unit) = Cbor.encode unit
+  decode = DHTData <$> Cbor.decode
 
 -- Kademlia uses Store, so we define a Store instance here as well.
 instance Store.Store DHTKey where

--- a/infra/Pos/Binary/Infra/Relay.hs
+++ b/infra/Pos/Binary/Infra/Relay.hs
@@ -6,6 +6,7 @@ import           Universum
 
 import           Pos.Binary.Class              (Bi (..), getWord8, label, labelS,
                                                 putConst, putField)
+import qualified Pos.Binary.Cbor               as Cbor
 import           Pos.Communication.Types.Relay (InvMsg (..), MempoolMsg (..), ReqMsg (..))
 
 instance Bi key => Bi (InvMsg key) where
@@ -24,3 +25,10 @@ instance Bi (MempoolMsg tag) where
         x <- getWord8
         when (x /= 228) $ fail "wrong byte"
         pure MempoolMsg
+
+instance Cbor.Bi (MempoolMsg tag) where
+  encode MempoolMsg = Cbor.encode (228 :: Word8)
+  decode = do
+    x <- Cbor.decode @Word8
+    when (x /= 228) $ fail "wrong byte"
+    pure MempoolMsg

--- a/infra/Pos/Binary/Infra/Slotting.hs
+++ b/infra/Pos/Binary/Infra/Slotting.hs
@@ -7,6 +7,7 @@ module Pos.Binary.Infra.Slotting
 import           Data.Time.Units    (Millisecond)
 
 import           Pos.Binary.Class   (Cons (..), Field (..), deriveSimpleBi)
+import qualified Pos.Binary.Cbor    as Cbor
 import           Pos.Binary.Core    ()
 import           Pos.Core.Timestamp (Timestamp)
 import           Pos.Core.Types     (EpochIndex)
@@ -18,10 +19,23 @@ deriveSimpleBi ''EpochSlottingData [
         Field [| esdStart        :: Timestamp   |]
     ]]
 
+Cbor.deriveSimpleBi ''EpochSlottingData [
+    Cbor.Cons 'EpochSlottingData [
+        Cbor.Field [| esdSlotDuration :: Millisecond |],
+        Cbor.Field [| esdStart        :: Timestamp   |]
+    ]]
+
 -- CSL-1122: add a test for serialization of 'SlottingData'
 deriveSimpleBi ''SlottingData [
     Cons 'SlottingData [
         Field [| sdPenult      :: EpochSlottingData |],
         Field [| sdLast        :: EpochSlottingData |],
         Field [| sdPenultEpoch :: EpochIndex        |]
+    ]]
+
+Cbor.deriveSimpleBi ''SlottingData [
+    Cbor.Cons 'SlottingData [
+        Cbor.Field [| sdPenult      :: EpochSlottingData |],
+        Cbor.Field [| sdLast        :: EpochSlottingData |],
+        Cbor.Field [| sdPenultEpoch :: EpochIndex        |]
     ]]

--- a/src/Pos/Binary/Delegation.hs
+++ b/src/Pos/Binary/Delegation.hs
@@ -11,7 +11,12 @@ import           Pos.Binary.Core      ()
 import           Pos.Binary.Crypto    ()
 import           Pos.Delegation.Types (DlgPayload (getDlgPayload), mkDlgPayload)
 import           Pos.Util.Util        (eitherToFail)
+import qualified Pos.Binary.Cbor      as Cbor
 
 instance Bi DlgPayload where
     sizeNPut = labelS "DlgPayload" $ putField getDlgPayload
     get = label "DlgPayload" $ eitherToFail . mkDlgPayload =<< get
+
+instance Cbor.Bi DlgPayload where
+  encode = Cbor.encode . getDlgPayload
+  decode = Cbor.decode >>= eitherToFail . mkDlgPayload

--- a/src/Pos/Binary/Relay.hs
+++ b/src/Pos/Binary/Relay.hs
@@ -5,6 +5,7 @@ module Pos.Binary.Relay () where
 import           Universum
 
 import           Pos.Binary.Class                 (Bi (..), label, putField, labelS)
+import qualified Pos.Binary.Cbor                  as Cbor
 import           Pos.Binary.Crypto                ()
 import           Pos.Binary.Ssc                   ()
 import           Pos.Binary.Update                ()
@@ -23,18 +24,42 @@ instance Bi (DataMsg (UpdateProposal, [UpdateVote])) where
             fail "get@DataMsg@Update: vote's uvProposalId must be equal UpId"
         pure $ DataMsg c
 
+instance Cbor.Bi (DataMsg (UpdateProposal, [UpdateVote])) where
+  encode = Cbor.encode . dmContents
+  decode = do
+    c@(up, votes) <- Cbor.decode
+    let !id = hash up
+    unless (all ((id ==) . uvProposalId) votes) $ fail "decode@DataMsg@Update: vote's uvProposalId must be equal UpId"
+    pure $ DataMsg c
+
 instance Bi (DataMsg UpdateVote) where
     sizeNPut = labelS "DataMsg UpdateVote" $ putField dmContents
     get = label "DataMsg UpdateVote" $ DataMsg <$> get
+
+instance Cbor.Bi (DataMsg UpdateVote) where
+  encode = Cbor.encode . dmContents
+  decode = DataMsg <$> Cbor.decode
 
 instance Bi (DataMsg ProxySKLight) where
     sizeNPut = labelS "DataMsg ProxySKLight" $ putField dmContents
     get = label "DataMsg ProxySKLight" $ DataMsg <$> get
 
+instance Cbor.Bi (DataMsg ProxySKLight) where
+  encode = Cbor.encode . dmContents
+  decode = DataMsg <$> Cbor.decode
+
 instance Bi (DataMsg ProxySKHeavy) where
     sizeNPut = labelS "DataMsg ProxySKHeavy" $ putField dmContents
     get = label "DataMsg ProxySKHeavy" $ DataMsg <$> get
 
+instance Cbor.Bi (DataMsg ProxySKHeavy) where
+  encode = Cbor.encode . dmContents
+  decode = DataMsg <$> Cbor.decode
+
 instance Bi (DataMsg ProxySKLightConfirmation) where
     sizeNPut = labelS "DataMsg ProxySKLightConfirmation" $ putField dmContents
     get = label "DataMsg ProxySKLightConfirmation" $ DataMsg <$> get
+
+instance Cbor.Bi (DataMsg ProxySKLightConfirmation) where
+  encode = Cbor.encode . dmContents
+  decode = DataMsg <$> Cbor.decode

--- a/src/Pos/Binary/Txp/Network.hs
+++ b/src/Pos/Binary/Txp/Network.hs
@@ -7,6 +7,7 @@ module Pos.Binary.Txp.Network
 import           Universum
 
 import           Pos.Binary.Class              (Bi (..), label, labelS, putField)
+import qualified Pos.Binary.Cbor               as Cbor
 import           Pos.Communication.Types.Relay (DataMsg (..))
 import           Pos.Txp.Network.Types         (TxMsgContents (..))
 
@@ -19,3 +20,7 @@ instance Bi (DataMsg TxMsgContents) where
         putField (\(DataMsg (TxMsgContents txAux)) -> txAux)
     get = label "DataMsg TxMsgContents" $
         DataMsg <$> (TxMsgContents <$> get)
+
+instance Cbor.Bi (DataMsg TxMsgContents) where
+  encode (DataMsg (TxMsgContents txAux)) = Cbor.encode txAux
+  decode = DataMsg <$> (TxMsgContents <$> Cbor.decode)

--- a/src/Pos/Util/BackupPhrase.hs
+++ b/src/Pos/Util/BackupPhrase.hs
@@ -18,6 +18,7 @@ import qualified Prelude
 
 import           Crypto.Hash         (Blake2b_256)
 import           Pos.Binary          (Bi (..), encode, label, labelS, putField)
+import qualified Pos.Binary.Cbor     as Cbor
 import           Pos.Crypto          (AbstractHash, EncryptedSecretKey, PassPhrase,
                                       SecretKey, VssKeyPair, deterministicKeyGen,
                                       deterministicVssKeyGen, safeDeterministicKeyGen,
@@ -33,6 +34,10 @@ newtype BackupPhrase = BackupPhrase
 instance Bi BackupPhrase where
     sizeNPut = labelS "BackupPhrase" $ putField bpToList
     get = label "BackupPhrase" $ BackupPhrase <$> get
+
+instance Cbor.Bi BackupPhrase where
+  encode = Cbor.encode
+  decode = BackupPhrase <$> Cbor.decode
 
 -- | Number of words in backup phrase
 backupPhraseWordsNum :: Int

--- a/src/Pos/Util/UserSecret.hs
+++ b/src/Pos/Util/UserSecret.hs
@@ -42,6 +42,7 @@ import           Universum
 
 import           Pos.Binary.Class      (Bi (..), decodeFull, encode, label, labelS,
                                         putField)
+import qualified Pos.Binary.Cbor       as Cbor
 import           Pos.Binary.Crypto     ()
 import           Pos.Crypto            (EncryptedSecretKey, SecretKey, VssKeyPair)
 
@@ -140,6 +141,23 @@ instance Bi UserSecret where
             & usPrimKey .~ pkey
             & usKeys .~ keys
             & usWalletSet .~ wset
+
+instance Cbor.Bi UserSecret where
+  encode us = Cbor.encodeListLen 4 <> Cbor.encode (_usVss us) <>
+                                      Cbor.encode (_usPrimKey us) <>
+                                      Cbor.encode (_usKeys us) <>
+                                      Cbor.encode (_usWalletSet us)
+  decode = do
+    Cbor.enforceSize "UserSecret" 4
+    vss  <- Cbor.decode
+    pkey <- Cbor.decode
+    keys <- Cbor.decode
+    wset <- Cbor.decode
+    return $ def
+        & usVss .~ vss
+        & usPrimKey .~ pkey
+        & usKeys .~ keys
+        & usWalletSet .~ wset
 
 #ifdef POSIX
 -- | Constant that defines file mode 600 (readable & writable only by owner).

--- a/src/Pos/Wallet/Web/Secret.hs
+++ b/src/Pos/Wallet/Web/Secret.hs
@@ -16,6 +16,7 @@ import           Formatting          (Format, bprint, build, later, (%))
 import           Universum
 
 import           Pos.Binary.Class    (Cons (..), Field (..), deriveSimpleBi)
+import qualified Pos.Binary.Cbor     as Cbor
 import           Pos.Crypto          (EncryptedSecretKey, encToPublic)
 import           Pos.Genesis         (accountGenesisIndex, wAddressGenesisIndex)
 import           Pos.Types           (addressF, makePubKeyAddress)
@@ -48,6 +49,14 @@ deriveSimpleBi ''WalletUserSecret [
         Field [| _wusWalletName :: Text               |],
         Field [| _wusAccounts   :: [(Word32, Text)]   |],
         Field [| _wusAddrs      :: [(Word32, Word32)] |]
+    ]]
+
+Cbor.deriveSimpleBi ''WalletUserSecret [
+    Cbor.Cons 'WalletUserSecret [
+        Cbor.Field [| _wusRootKey    :: EncryptedSecretKey |],
+        Cbor.Field [| _wusWalletName :: Text               |],
+        Cbor.Field [| _wusAccounts   :: [(Word32, Text)]   |],
+        Cbor.Field [| _wusAddrs      :: [(Word32, Word32)] |]
     ]]
 
 mkGenesisWalletUserSecret :: EncryptedSecretKey -> WalletUserSecret

--- a/update/Pos/Binary/Update.hs
+++ b/update/Pos/Binary/Update.hs
@@ -20,7 +20,7 @@ import           Pos.Core                   (ApplicationName, BlockVersion,
                                              FlatSlotId, HeaderHash, NumSoftwareVersion,
                                              ScriptVersion, SlotId, SoftwareVersion,
                                              StakeholderId, TxFeePolicy)
-import           Pos.Crypto                 (Hash, SignTag (SignUSVote), checkSig)
+import           Pos.Crypto                 (Hash, SignTag (SignUSVote), Signature, checkSig)
 import           Pos.Slotting.Types         (SlottingData)
 import qualified Pos.Update.Core.Types      as U
 import qualified Pos.Update.Poll.Types      as U
@@ -31,6 +31,12 @@ instance Bi U.SystemTag where
         putAsciiString1b tag
     get = label "SystemTag" $
         U.mkSystemTag . toText =<< getAsciiString1b "SystemTag" U.systemTagMaxLength
+
+instance Cbor.Bi U.SystemTag where
+  encode = Cbor.encode . U.getSystemTag
+  decode = Cbor.decode >>= \decoded -> case U.mkSystemTag decoded of
+    Left e   -> fail e
+    Right st -> pure st
 
 instance Bi U.UpdateVote where
     sizeNPut = labelS "UpdateVote" $
@@ -51,12 +57,36 @@ instance Bi U.UpdateVote where
             fail "Pos.Binary.Update: UpdateVote: invalid signature"
         return U.UpdateVote {..}
 
+instance Cbor.Bi U.UpdateVote where
+  encode uv =  Cbor.encodeListLen 4
+            <> Cbor.encode (U.uvKey uv)
+            <> Cbor.encode (U.uvProposalId uv)
+            <> Cbor.encode (U.uvDecision uv)
+            <> Cbor.encode (U.uvSignature uv)
+  decode = do
+    Cbor.enforceSize "UpdateVote" 4
+    k <- Cbor.decode
+    p <- Cbor.decode
+    d <- Cbor.decode
+    s <- Cbor.decode
+    let sigValid = checkSig SignUSVote k (p, d) s
+    unless sigValid $ fail "Pos.Binary.Update: UpdateVote: invalid signature"
+    return $ U.UpdateVote k p d s
+
 deriveSimpleBi ''U.UpdateData [
     Cons 'U.UpdateData [
         Field [| U.udAppDiffHash  :: Hash Raw |],
         Field [| U.udPkgHash      :: Hash Raw |],
         Field [| U.udUpdaterHash  :: Hash Raw |],
         Field [| U.udMetadataHash :: Hash Raw |]
+    ]]
+
+Cbor.deriveSimpleBi ''U.UpdateData [
+    Cbor.Cons 'U.UpdateData [
+        Cbor.Field [| U.udAppDiffHash  :: Hash Raw |],
+        Cbor.Field [| U.udPkgHash      :: Hash Raw |],
+        Cbor.Field [| U.udUpdaterHash  :: Hash Raw |],
+        Cbor.Field [| U.udMetadataHash :: Hash Raw |]
     ]]
 
 deriveSimpleBi ''U.BlockVersionModifier [
@@ -74,6 +104,23 @@ deriveSimpleBi ''U.BlockVersionModifier [
         Field [| U.bvmUpdateImplicit    :: FlatSlotId        |],
         Field [| U.bvmUpdateSoftforkThd :: CoinPortion       |],
         Field [| U.bvmTxFeePolicy       :: Maybe TxFeePolicy |]
+    ]]
+
+Cbor.deriveSimpleBi ''U.BlockVersionModifier [
+    Cbor.Cons 'U.BlockVersionModifier [
+        Cbor.Field [| U.bvmScriptVersion     :: ScriptVersion     |],
+        Cbor.Field [| U.bvmSlotDuration      :: Millisecond       |],
+        Cbor.Field [| U.bvmMaxBlockSize      :: Byte              |],
+        Cbor.Field [| U.bvmMaxHeaderSize     :: Byte              |],
+        Cbor.Field [| U.bvmMaxTxSize         :: Byte              |],
+        Cbor.Field [| U.bvmMaxProposalSize   :: Byte              |],
+        Cbor.Field [| U.bvmMpcThd            :: CoinPortion       |],
+        Cbor.Field [| U.bvmHeavyDelThd       :: CoinPortion       |],
+        Cbor.Field [| U.bvmUpdateVoteThd     :: CoinPortion       |],
+        Cbor.Field [| U.bvmUpdateProposalThd :: CoinPortion       |],
+        Cbor.Field [| U.bvmUpdateImplicit    :: FlatSlotId        |],
+        Cbor.Field [| U.bvmUpdateSoftforkThd :: CoinPortion       |],
+        Cbor.Field [| U.bvmTxFeePolicy       :: Maybe TxFeePolicy |]
     ]]
 
 instance Bi U.UpdateProposal where
@@ -95,6 +142,28 @@ instance Bi U.UpdateProposal where
         i <- get
         U.mkUpdateProposal d r a t u t' i
 
+instance Cbor.Bi U.UpdateProposal where
+  encode up =  Cbor.encodeListLen 7
+            <> Cbor.encode (U.upBlockVersion up)
+            <> Cbor.encode (U.upBlockVersionMod up)
+            <> Cbor.encode (U.upSoftwareVersion up)
+            <> Cbor.encode (U.upData up)
+            <> Cbor.encode (U.upAttributes up)
+            <> Cbor.encode (U.upFrom up)
+            <> Cbor.encode (U.upSignature up)
+  decode = do
+    Cbor.enforceSize "UpdateProposal" 7
+    up <- U.mkUpdateProposal <$> Cbor.decode
+                             <*> Cbor.decode
+                             <*> Cbor.decode
+                             <*> Cbor.decode
+                             <*> Cbor.decode
+                             <*> Cbor.decode
+                             <*> Cbor.decode
+    case up of
+      Left e  -> fail e
+      Right p -> pure p
+
 deriveSimpleBi ''U.UpdateProposalToSign [
     Cons 'U.UpdateProposalToSign [
         Field [| U.upsBV   :: BlockVersion                     |],
@@ -104,10 +173,25 @@ deriveSimpleBi ''U.UpdateProposalToSign [
         Field [| U.upsAttr :: U.UpAttributes                   |]
     ]]
 
+Cbor.deriveSimpleBi ''U.UpdateProposalToSign [
+    Cbor.Cons 'U.UpdateProposalToSign [
+        Cbor.Field [| U.upsBV   :: BlockVersion                     |],
+        Cbor.Field [| U.upsBVM  :: U.BlockVersionModifier           |],
+        Cbor.Field [| U.upsSV   :: SoftwareVersion                  |],
+        Cbor.Field [| U.upsData :: HashMap U.SystemTag U.UpdateData |],
+        Cbor.Field [| U.upsAttr :: U.UpAttributes                   |]
+    ]]
+
 deriveSimpleBi ''U.UpdatePayload [
     Cons 'U.UpdatePayload [
         Field [| U.upProposal :: Maybe U.UpdateProposal |],
         Field [| U.upVotes    :: [U.UpdateVote]         |]
+    ]]
+
+Cbor.deriveSimpleBi ''U.UpdatePayload [
+    Cbor.Cons 'U.UpdatePayload [
+        Cbor.Field [| U.upProposal :: Maybe U.UpdateProposal |],
+        Cbor.Field [| U.upVotes    :: [U.UpdateVote]         |]
     ]]
 
 deriveSimpleBi ''U.VoteState [
@@ -115,6 +199,12 @@ deriveSimpleBi ''U.VoteState [
     Cons 'U.NegativeVote [],
     Cons 'U.PositiveRevote [],
     Cons 'U.NegativeRevote []]
+
+Cbor.deriveSimpleBi ''U.VoteState [
+    Cbor.Cons 'U.PositiveVote [],
+    Cbor.Cons 'U.NegativeVote [],
+    Cbor.Cons 'U.PositiveRevote [],
+    Cbor.Cons 'U.NegativeRevote []]
 
 instance Bi a => Bi (U.PrevValue a) where
     sizeNPut = labelS "PrevValue" $
@@ -125,6 +215,17 @@ instance Bi a => Bi (U.PrevValue a) where
         2 -> U.PrevValue <$> get
         3 -> pure U.NoExist
         x -> fail $ "get@PrevValue: invalid tag: " <> show x
+
+instance Cbor.Bi a => Cbor.Bi (U.PrevValue a) where
+  encode (U.PrevValue a) = Cbor.encodeListLen 2 <> Cbor.encode (2 :: Word8) <> Cbor.encode a
+  encode U.NoExist       = Cbor.encodeListLen 1 <> Cbor.encode (3 :: Word8)
+  decode = do
+    len <- Cbor.decodeListLen
+    tag <- Cbor.decode @Word8
+    case (len, tag) of
+      (2,2) -> U.PrevValue <$> Cbor.decode
+      (1,3) -> pure U.NoExist
+      _     -> fail $ "decode@PrevValue: invalid tag: " <> show tag
 
 deriveSimpleBi ''U.USUndo [
     Cons 'U.USUndo [
@@ -148,15 +249,37 @@ deriveSimpleBi ''U.USUndo [
                      :: Maybe SlottingData                       |]
     ]]
 
+Cbor.deriveSimpleBi ''U.USUndo [
+    Cbor.Cons 'U.USUndo [
+        Cbor.Field [| U.unChangedBV :: HashMap BlockVersion (U.PrevValue U.BlockVersionState)                |],
+        Cbor.Field [| U.unLastAdoptedBV :: Maybe BlockVersion                                                |],
+        Cbor.Field [| U.unChangedProps :: HashMap U.UpId (U.PrevValue U.ProposalState)                       |],
+        Cbor.Field [| U.unChangedSV :: HashMap ApplicationName (U.PrevValue NumSoftwareVersion)              |],
+        Cbor.Field [| U.unChangedConfProps :: HashMap SoftwareVersion (U.PrevValue U.ConfirmedProposalState) |],
+        Cbor.Field [| U.unPrevProposers :: Maybe (HashSet StakeholderId)                                     |],
+        Cbor.Field [| U.unSlottingData :: Maybe SlottingData                                                 |]
+    ]]
+
 deriveSimpleBi ''U.UpsExtra [
     Cons 'U.UpsExtra [
         Field [| U.ueProposedBlk :: HeaderHash |]
+    ]]
+
+Cbor.deriveSimpleBi ''U.UpsExtra [
+    Cbor.Cons 'U.UpsExtra [
+        Cbor.Field [| U.ueProposedBlk :: HeaderHash |]
     ]]
 
 deriveSimpleBi ''U.DpsExtra [
     Cons 'U.DpsExtra [
         Field [| U.deDecidedBlk :: HeaderHash |],
         Field [| U.deImplicit   :: Bool       |]
+    ]]
+
+Cbor.deriveSimpleBi ''U.DpsExtra [
+    Cbor.Cons 'U.DpsExtra [
+        Cbor.Field [| U.deDecidedBlk :: HeaderHash |],
+        Cbor.Field [| U.deImplicit   :: Bool       |]
     ]]
 
 deriveSimpleBi ''U.UndecidedProposalState [
@@ -169,6 +292,16 @@ deriveSimpleBi ''U.UndecidedProposalState [
         Field [| U.upsExtra         :: Maybe U.UpsExtra   |]
     ]]
 
+Cbor.deriveSimpleBi ''U.UndecidedProposalState [
+    Cbor.Cons 'U.UndecidedProposalState [
+        Cbor.Field [| U.upsVotes         :: U.StakeholderVotes |],
+        Cbor.Field [| U.upsProposal      :: U.UpdateProposal   |],
+        Cbor.Field [| U.upsSlot          :: SlotId             |],
+        Cbor.Field [| U.upsPositiveStake :: Coin               |],
+        Cbor.Field [| U.upsNegativeStake :: Coin               |],
+        Cbor.Field [| U.upsExtra         :: Maybe U.UpsExtra   |]
+    ]]
+
 deriveSimpleBi ''U.DecidedProposalState [
     Cons 'U.DecidedProposalState [
         Field [| U.dpsDecision   :: Bool                     |],
@@ -177,12 +310,28 @@ deriveSimpleBi ''U.DecidedProposalState [
         Field [| U.dpsExtra      :: Maybe U.DpsExtra         |]
     ]]
 
+Cbor.deriveSimpleBi ''U.DecidedProposalState [
+    Cbor.Cons 'U.DecidedProposalState [
+        Cbor.Field [| U.dpsDecision   :: Bool                     |],
+        Cbor.Field [| U.dpsUndecided  :: U.UndecidedProposalState |],
+        Cbor.Field [| U.dpsDifficulty :: Maybe ChainDifficulty    |],
+        Cbor.Field [| U.dpsExtra      :: Maybe U.DpsExtra         |]
+    ]]
+
 deriveSimpleBi ''U.ProposalState [
     Cons 'U.PSUndecided [
         Field [| U.unPSUndecided :: U.UndecidedProposalState |]
     ],
     Cons 'U.PSDecided [
         Field [| U.unPSDecided :: U.DecidedProposalState |]
+    ]]
+
+Cbor.deriveSimpleBi ''U.ProposalState [
+    Cbor.Cons 'U.PSUndecided [
+        Cbor.Field [| U.unPSUndecided :: U.UndecidedProposalState |]
+    ],
+    Cbor.Cons 'U.PSDecided [
+        Cbor.Field [| U.unPSDecided :: U.DecidedProposalState |]
     ]]
 
 deriveSimpleBi ''U.ConfirmedProposalState [
@@ -198,6 +347,19 @@ deriveSimpleBi ''U.ConfirmedProposalState [
         Field [| U.cpsNegativeStake  :: Coin               |]
     ]]
 
+Cbor.deriveSimpleBi ''U.ConfirmedProposalState [
+    Cbor.Cons 'U.ConfirmedProposalState [
+        Cbor.Field [| U.cpsUpdateProposal :: U.UpdateProposal   |],
+        Cbor.Field [| U.cpsImplicit       :: Bool               |],
+        Cbor.Field [| U.cpsProposed       :: HeaderHash         |],
+        Cbor.Field [| U.cpsDecided        :: HeaderHash         |],
+        Cbor.Field [| U.cpsConfirmed      :: HeaderHash         |],
+        Cbor.Field [| U.cpsAdopted        :: Maybe HeaderHash   |],
+        Cbor.Field [| U.cpsVotes          :: U.StakeholderVotes |],
+        Cbor.Field [| U.cpsPositiveStake  :: Coin               |],
+        Cbor.Field [| U.cpsNegativeStake  :: Coin               |]
+    ]]
+
 deriveSimpleBi ''U.BlockVersionState [
     Cons 'U.BlockVersionState [
         Field [| U.bvsModifier          :: U.BlockVersionModifier |],
@@ -206,4 +368,14 @@ deriveSimpleBi ''U.BlockVersionState [
         Field [| U.bvsIssuersUnstable   :: HashSet StakeholderId  |],
         Field [| U.bvsLastBlockStable   :: Maybe HeaderHash       |],
         Field [| U.bvsLastBlockUnstable :: Maybe HeaderHash       |]
+    ]]
+
+Cbor.deriveSimpleBi ''U.BlockVersionState [
+    Cbor.Cons 'U.BlockVersionState [
+        Cbor.Field [| U.bvsModifier          :: U.BlockVersionModifier |],
+        Cbor.Field [| U.bvsIsConfirmed       :: Bool                   |],
+        Cbor.Field [| U.bvsIssuersStable     :: HashSet StakeholderId  |],
+        Cbor.Field [| U.bvsIssuersUnstable   :: HashSet StakeholderId  |],
+        Cbor.Field [| U.bvsLastBlockStable   :: Maybe HeaderHash       |],
+        Cbor.Field [| U.bvsLastBlockUnstable :: Maybe HeaderHash       |]
     ]]


### PR DESCRIPTION
This small PR adds some instances (list below) and correct a faulty instance for `TxFeePolicy`. The problem, as has been rightly pointed out, was that it was not really resilient to change. The culprit was _not_ serialising everything as a `ByteString` blob, so that we could "swap container type" with no harm.

The same underlying idea has been crystallised in the `Test` module using a type `U` mimicking the real scenario where we need to swap between different representation of the type whilst preserving it. All the credits goes to @arybczak for coming up with the idea!

I have indeed verified, armed with this new `Property`, that my previous instance was faulty and that this new one is indeed sound. I love QC! 😉 

Instances added in this PR:

- [x] StakeDistribution
- [x] ApplicationName
- [x] SoftwareVersion
- [x] BlockVersion
- [x] Commitment
- [x] CommitmentsMap
- [x] VssCertificate
- [x] Opening
- [x] GtPayload
- [x] GtProof
- [x] (DataMsg MCCommitment)
- [x] (DataMsg MCOpening)
- [x] (DataMsg MCShares)
- [x] (DataMsg MCVssCertificate)
- [x] DHTKey
- [x] DHTData
- [x] MessageName
- [x] MsgGetHeaders
- [x] MsgGetBlocks
- [x] HandlerSpec
- [x] VerInfo
- [x] DlgPayload
- [x] Attributes () **(Just a placeholder waiting for the rework)**
- [x] EpochSlottingData
- [x] SlottingData
- [x] (DataMsg (UpdateProposal, [UpdateVote]))
- [x] (DataMsg UpdateVote)
- [x] (DataMsg ProxySKLight)
- [x] (DataMsg ProxySKHeavy)
- [x] (DataMsg ProxySKLightConfirmation)
- [x] SystemTag
- [x] UpdateVote
- [x] UpdateData
- [x] BlockVersionModifier
- [x] UpdateProposal
- [x] UpdateProposalToSign
- [x] UpdatePayload
- [x] VoteState
- [x] (U.PrevValue a)
- [x] USUndo
- [x] UpsExtra
- [x] DpsExtra
- [x] UndecidedProposalState
- [x] DecidedProposalState
- [x] ProposalState
- [x] ConfirmedProposalState
- [x] BlockVersionState
- [x] Address **(Just stubbed as Andrzej is actively working on it)**
- [x] (MerkleTree a)
- [x] (MerkleRoot a)
- [x] TxIn
- [x] TxOut
- [x] TxOutAux
- [x] Tx
- [x] TxInWitness
- [x] TxDistribution
- [x] TxSigData
- [x] TxAux
- [x] TxProof
- [x] TxPayload
- [x] UserSecret
- [x] WalletUserSecret
- [x] BackupPhrase
- [x] (DataMsg TxMsgContents)

cc @dcoutts