### PR TITLE
Add all the remaining instances

### DIFF
--- a/cardano-sl.cabal
+++ b/cardano-sl.cabal
@@ -597,6 +597,7 @@ test-suite cardano-test
                      , cardano-sl-update
                      , cardano-sl-ssc
                      , cardano-sl
+                     , cborg
                      , cereal
                      , containers
                      , cryptonite
@@ -604,6 +605,7 @@ test-suite cardano-test
                      , derive
                      , ether
                      , formatting
+                     , generic-arbitrary
                      , hspec
                      , kademlia
                      , lens

--- a/core/Pos/Binary/Cbor/Class.hs
+++ b/core/Pos/Binary/Cbor/Class.hs
@@ -132,6 +132,10 @@ instance Bi Int32 where
     encode = encodeInt32
     decode = decodeInt32
 
+instance Bi Int64 where
+    encode = encodeInt64
+    decode = decodeInt64
+
 instance Bi Nano where
     encode (MkFixed resolution) = encodeInteger resolution
     decode = MkFixed <$> decodeInteger

--- a/core/Pos/Binary/Cbor/Test.hs
+++ b/core/Pos/Binary/Cbor/Test.hs
@@ -14,6 +14,7 @@ import           Pos.Core.Arbitrary()
 import           Pos.Binary.Core.Script()
 import           Pos.Core.Types
 import           Pos.Core.Genesis.Types
+import           Pos.Binary.Class.Numbers
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
@@ -119,6 +120,19 @@ qc = quickCheckWith (stdArgs { maxSuccess = 1000 })
 -- of a bigger testsuite.
 soundInstancesTest :: IO ()
 soundInstancesTest = do
+  qc (soundInstanceProperty @(UnsignedVarInt Int) Proxy)
+  qc (soundInstanceProperty @(SignedVarInt Int) Proxy)
+  qc (soundInstanceProperty @(FixedSizeInt Int) Proxy)
+  qc (soundInstanceProperty @(UnsignedVarInt Int64) Proxy)
+  qc (soundInstanceProperty @(SignedVarInt Int64) Proxy)
+  qc (soundInstanceProperty @(FixedSizeInt Int64) Proxy)
+  qc (soundInstanceProperty @(UnsignedVarInt Word) Proxy)
+  qc (soundInstanceProperty @(FixedSizeInt Word) Proxy)
+  qc (soundInstanceProperty @(UnsignedVarInt Word16) Proxy)
+  qc (soundInstanceProperty @(UnsignedVarInt Word32) Proxy)
+  qc (soundInstanceProperty @(UnsignedVarInt Word64) Proxy)
+  qc (soundInstanceProperty @TinyVarInt Proxy)
+  qc (soundInstanceProperty @Int64 Proxy)
   qc (soundInstanceProperty @MyScript Proxy)
   qc (soundInstanceProperty @Coeff Proxy)
   qc (soundInstanceProperty @TxSizeLinear Proxy)

--- a/core/Pos/Binary/Class/Numbers.hs
+++ b/core/Pos/Binary/Class/Numbers.hs
@@ -31,6 +31,7 @@ import qualified Data.Store.Internal    as Store
 import           GHC.TypeLits           (ErrorMessage (..), TypeError)
 
 import           Pos.Binary.Class.Core  (Bi (..), label, limitGet)
+import qualified Pos.Binary.Cbor        as Cbor
 import           Pos.Binary.Class.Store (convertSize)
 
 -- CSL-1122 make sure it's indeed serialized as one byte
@@ -240,6 +241,10 @@ instance Bi (UnsignedVarInt Int) where
               getUnsignedVarIntSize (fromIntegral a :: Word)
     {-# INLINE size #-}
 
+instance Cbor.Bi (UnsignedVarInt Int) where
+  encode = Cbor.encode . getUnsignedVarInt
+  decode = UnsignedVarInt <$> Cbor.decode
+
 instance Bi (SignedVarInt Int) where
     put (SignedVarInt a) = putSignedVarInt a
     {-# INLINE put #-}
@@ -249,6 +254,9 @@ instance Bi (SignedVarInt Int) where
     size = VarSize $ getSignedVarIntSize . getSignedVarInt
     {-# INLINE size #-}
 
+instance Cbor.Bi (SignedVarInt Int) where
+  encode = Cbor.encode . getSignedVarInt
+  decode = SignedVarInt <$> Cbor.decode
 
 -- Is this instance valid at all? Is it int32 or int64 after all?
 instance Bi (FixedSizeInt Int) where
@@ -262,6 +270,10 @@ instance Bi (FixedSizeInt Int) where
 
 -- Int64
 
+instance Cbor.Bi (FixedSizeInt Int) where
+  encode = Cbor.encode . getFixedSizeInt
+  decode = FixedSizeInt <$> Cbor.decode
+
 instance Bi (UnsignedVarInt Int64) where
     put (UnsignedVarInt a) = putUnsignedVarInt (fromIntegral a :: Word64)
     {-# INLINE put #-}
@@ -273,6 +285,10 @@ instance Bi (UnsignedVarInt Int64) where
               getUnsignedVarIntSize (fromIntegral a :: Word64)
     {-# INLINE size #-}
 
+instance Cbor.Bi (UnsignedVarInt Int64) where
+  encode = Cbor.encode . getUnsignedVarInt
+  decode = UnsignedVarInt <$> Cbor.decode
+
 instance Bi (SignedVarInt Int64) where
     put (SignedVarInt a) = putSignedVarInt a
     {-# INLINE put #-}
@@ -282,6 +298,10 @@ instance Bi (SignedVarInt Int64) where
     size = VarSize $ getSignedVarIntSize . getSignedVarInt
     {-# INLINE size #-}
 
+instance Cbor.Bi (SignedVarInt Int64) where
+  encode = Cbor.encode . getSignedVarInt
+  decode = SignedVarInt <$> Cbor.decode
+
 instance Bi (FixedSizeInt Int64) where
     put (FixedSizeInt a) = Store.poke a -- CSL-1122 fix endianess
     {-# INLINE put #-}
@@ -290,6 +310,10 @@ instance Bi (FixedSizeInt Int64) where
     {-# INLINE get #-}
     size = convertSize getFixedSizeInt Store.size
     {-# INLINE size #-}
+
+instance Cbor.Bi (FixedSizeInt Int64) where
+  encode = Cbor.encode . getFixedSizeInt
+  decode = FixedSizeInt <$> Cbor.decode
 
 -- Word
 
@@ -302,6 +326,10 @@ instance Bi (UnsignedVarInt Word) where
     size = VarSize $ getUnsignedVarIntSize . getUnsignedVarInt
     {-# INLINE size #-}
 
+instance Cbor.Bi (UnsignedVarInt Word) where
+  encode = Cbor.encode . getUnsignedVarInt
+  decode = UnsignedVarInt <$> Cbor.decode
+
 -- Is this instance valid at all? Is it word32 or word64 after all?
 instance Bi (FixedSizeInt Word) where
     put (FixedSizeInt a) = Store.poke a -- CSL-1122 fix endianess
@@ -311,6 +339,10 @@ instance Bi (FixedSizeInt Word) where
     {-# INLINE get #-}
     size = convertSize getFixedSizeInt Store.size
     {-# INLINE size #-}
+
+instance Cbor.Bi (FixedSizeInt Word) where
+  encode = Cbor.encode . getFixedSizeInt
+  decode = FixedSizeInt <$> Cbor.decode
 
 -- Word16
 
@@ -323,6 +355,10 @@ instance Bi (UnsignedVarInt Word16) where
     size = VarSize $ getUnsignedVarIntSize . getUnsignedVarInt
     {-# INLINE size #-}
 
+instance Cbor.Bi (UnsignedVarInt Word16) where
+  encode = Cbor.encode . getUnsignedVarInt
+  decode = UnsignedVarInt <$> Cbor.decode
+
 -- Word32
 
 instance Bi (UnsignedVarInt Word32) where
@@ -334,6 +370,10 @@ instance Bi (UnsignedVarInt Word32) where
     size = VarSize $ getUnsignedVarIntSize . getUnsignedVarInt
     {-# INLINE size #-}
 
+instance Cbor.Bi (UnsignedVarInt Word32) where
+  encode = Cbor.encode . getUnsignedVarInt
+  decode = UnsignedVarInt <$> Cbor.decode
+
 -- Word64
 
 instance Bi (UnsignedVarInt Word64) where
@@ -344,6 +384,10 @@ instance Bi (UnsignedVarInt Word64) where
     {-# INLINE get #-}
     size = VarSize $ getUnsignedVarIntSize . getUnsignedVarInt
     {-# INLINE size #-}
+
+instance Cbor.Bi (UnsignedVarInt Word64) where
+  encode = Cbor.encode . getUnsignedVarInt
+  decode = UnsignedVarInt <$> Cbor.decode
 
 -- TinyVarInt
 
@@ -357,3 +401,7 @@ instance Bi TinyVarInt where
     {-# INLINE get #-}
     size = VarSize $ getTinyVarIntSize . getTinyVarInt
     {-# INLINE size #-}
+
+instance Cbor.Bi TinyVarInt where
+  encode = Cbor.encode . getTinyVarInt
+  decode = TinyVarInt <$> Cbor.decode

--- a/core/Pos/Binary/Core/Block.hs
+++ b/core/Pos/Binary/Core/Block.hs
@@ -8,6 +8,7 @@ import           Universum
 
 import           Pos.Binary.Class   (Bi (..), label, labelS, putConst, putField)
 import qualified Pos.Core.Block     as T
+import qualified Pos.Binary.Cbor    as Cbor
 import           Pos.Core.Constants (protocolMagic)
 import qualified Pos.Core.Types     as T
 import           Pos.Util.Util      (eitherToFail)
@@ -18,6 +19,10 @@ instance Bi T.BlockHeaderStub where
     size  = error "somebody tried to binary size BlockHeaderStub"
     put _ = error "somebody tried to binary put BlockHeaderStub"
     get   = error "somebody tried to binary get BlockHeaderStub"
+
+instance Cbor.Bi T.BlockHeaderStub where
+  encode = error "somebody tried to binary encode BlockHeaderStub"
+  decode = fail  "somebody tried to binary decode BlockHeaderStub"
 
 instance ( Bi (T.BHeaderHash b)
          , Bi (T.BodyProof b)
@@ -42,6 +47,30 @@ instance ( Bi (T.BHeaderHash b)
         extra <- get
         eitherToFail $ T.recreateGenericHeader prevBlock bodyProof consensus extra
 
+instance ( Cbor.Bi (T.BHeaderHash b)
+         , Cbor.Bi (T.BodyProof b)
+         , Cbor.Bi (T.ConsensusData b)
+         , Cbor.Bi (T.ExtraHeaderData b)
+         , T.BlockchainHelpers b
+         ) =>
+         Cbor.Bi (T.GenericBlockHeader b) where
+  encode bh =  Cbor.encodeListLen 5
+            <> Cbor.encode protocolMagic
+            <> Cbor.encode (T._gbhPrevBlock bh)
+            <> Cbor.encode (T._gbhBodyProof bh)
+            <> Cbor.encode (T._gbhConsensus bh)
+            <> Cbor.encode (T._gbhExtra bh)
+  decode = do
+    Cbor.enforceSize "GenericBlockHeader b" 5
+    blockMagic <- Cbor.decode
+    when (blockMagic /= protocolMagic) $
+        fail $ "GenericBlockHeader failed with wrong magic: " <> show blockMagic
+    prevBlock <- Cbor.decode
+    bodyProof <- Cbor.decode
+    consensus <- Cbor.decode
+    extra     <- Cbor.decode
+    eitherToFail $ T.recreateGenericHeader prevBlock bodyProof consensus extra
+
 instance ( Bi (T.BHeaderHash b)
          , Bi (T.BodyProof b)
          , Bi (T.ConsensusData b)
@@ -61,3 +90,23 @@ instance ( Bi (T.BHeaderHash b)
             body <- get
             extra <- get
             eitherToFail $ T.recreateGenericBlock header body extra
+
+instance ( Cbor.Bi (T.BHeaderHash b)
+         , Cbor.Bi (T.BodyProof b)
+         , Cbor.Bi (T.ConsensusData b)
+         , Cbor.Bi (T.ExtraHeaderData b)
+         , Cbor.Bi (T.Body b)
+         , Cbor.Bi (T.ExtraBodyData b)
+         , T.BlockchainHelpers b
+         ) =>
+         Cbor.Bi (T.GenericBlock b) where
+  encode gb =  Cbor.encodeListLen 3
+            <> Cbor.encode (T._gbHeader gb)
+            <> Cbor.encode (T._gbBody gb)
+            <> Cbor.encode (T._gbExtra gb)
+  decode = do
+    Cbor.enforceSize "GenericBlock" 3
+    header <- Cbor.decode
+    body   <- Cbor.decode
+    extra  <- Cbor.decode
+    eitherToFail $ T.recreateGenericBlock header body extra

--- a/core/Pos/Binary/Core/Genesis.hs
+++ b/core/Pos/Binary/Core/Genesis.hs
@@ -74,3 +74,13 @@ instance Bi GenesisCoreData where
         labelS "GenesisCoreData" $
             putField gcdAddrDistribution <>
             putField gcdBootstrapStakeholders
+
+instance Cbor.Bi GenesisCoreData where
+  encode (UnsafeGenesisCoreData addr stakes) = Cbor.encodeListLen 2 <> Cbor.encode addr <> Cbor.encode stakes
+  decode = do
+    Cbor.enforceSize "GenesisCoreData" 2
+    addrDistribution      <- Cbor.decode
+    bootstrapStakeholders <- Cbor.decode
+    case mkGenesisCoreData addrDistribution bootstrapStakeholders of
+        Left e  -> fail $ "Couldn't construct genesis data: " <> e
+        Right x -> pure x

--- a/core/Pos/Core/Arbitrary.hs
+++ b/core/Pos/Core/Arbitrary.hs
@@ -31,7 +31,8 @@ import           Test.QuickCheck.Instances         ()
 
 import           Pos.Binary.Class                  (AsBinary, FixedSizeInt (..),
                                                     SignedVarInt (..),
-                                                    UnsignedVarInt (..))
+                                                    UnsignedVarInt (..),
+                                                    TinyVarInt(..))
 import           Pos.Binary.Core                   ()
 import           Pos.Binary.Crypto                 ()
 import           Pos.Core.Address                  (makePubKeyAddress, makeRedeemAddress,
@@ -422,3 +423,4 @@ instance Arbitrary SmallHashMap where
 deriving instance Arbitrary a => Arbitrary (UnsignedVarInt a)
 deriving instance Arbitrary a => Arbitrary (SignedVarInt a)
 deriving instance Arbitrary a => Arbitrary (FixedSizeInt a)
+deriving instance Arbitrary TinyVarInt

--- a/core/Pos/Util/Chrono.hs
+++ b/core/Pos/Util/Chrono.hs
@@ -23,18 +23,19 @@ import qualified GHC.Exts           as IL
 import           Test.QuickCheck    (Arbitrary)
 
 import           Pos.Binary.Class   (Bi)
+import qualified Pos.Binary.Cbor    as Cbor
 
 newtype NewestFirst f a = NewestFirst {getNewestFirst :: f a}
   deriving (Eq, Ord, Show,
             Functor, Foldable, Traversable,
             Container, NontrivialContainer,
-            Binary, Bi,
+            Binary, Bi, Cbor.Bi,
             Arbitrary)
 newtype OldestFirst f a = OldestFirst {getOldestFirst :: f a}
   deriving (Eq, Ord, Show,
             Functor, Foldable, Traversable,
             Container, NontrivialContainer,
-            Binary, Bi,
+            Binary, Bi, Cbor.Bi,
             Arbitrary)
 
 makeWrapped ''NewestFirst

--- a/godtossing/Pos/Binary/GodTossing/Toss.hs
+++ b/godtossing/Pos/Binary/GodTossing/Toss.hs
@@ -5,6 +5,7 @@ module Pos.Binary.GodTossing.Toss
        ) where
 
 import           Pos.Binary.Class              (Cons (..), Field (..), deriveSimpleBi)
+import qualified Pos.Binary.Cbor               as Cbor
 import           Pos.Ssc.GodTossing.Core       (CommitmentsMap, OpeningsMap, SharesMap,
                                                 VssCertificatesMap)
 import           Pos.Ssc.GodTossing.Toss.Types (GtTag (..), TossModifier (..))
@@ -15,10 +16,24 @@ deriveSimpleBi ''GtTag [
     Cons 'SharesMsg [],
     Cons 'VssCertificateMsg []]
 
+Cbor.deriveSimpleBi ''GtTag [
+    Cbor.Cons 'CommitmentMsg [],
+    Cbor.Cons 'OpeningMsg [],
+    Cbor.Cons 'SharesMsg [],
+    Cbor.Cons 'VssCertificateMsg []]
+
 deriveSimpleBi ''TossModifier [
     Cons 'TossModifier [
         Field [| _tmCommitments  :: CommitmentsMap     |],
         Field [| _tmOpenings     :: OpeningsMap        |],
         Field [| _tmShares       :: SharesMap          |],
         Field [| _tmCertificates :: VssCertificatesMap |]
+    ]]
+
+Cbor.deriveSimpleBi ''TossModifier [
+    Cbor.Cons 'TossModifier [
+        Cbor.Field [| _tmCommitments  :: CommitmentsMap     |],
+        Cbor.Field [| _tmOpenings     :: OpeningsMap        |],
+        Cbor.Field [| _tmShares       :: SharesMap          |],
+        Cbor.Field [| _tmCertificates :: VssCertificatesMap |]
     ]]

--- a/godtossing/Pos/Binary/GodTossing/Types.hs
+++ b/godtossing/Pos/Binary/GodTossing/Types.hs
@@ -5,6 +5,7 @@ module Pos.Binary.GodTossing.Types () where
 import           Universum
 
 import           Pos.Binary.Class                 (Cons (..), Field (..), deriveSimpleBi)
+import qualified Pos.Binary.Cbor                  as Cbor
 import           Pos.Core.Types                   (EpochIndex, EpochOrSlot, StakeholderId)
 import           Pos.Ssc.GodTossing.Core          (CommitmentsMap, Opening, OpeningsMap,
                                                    SharesMap, SignedCommitment,
@@ -26,12 +27,32 @@ deriveSimpleBi ''VssCertData [
                                                       VssCertificate)) |]
     ]]
 
+Cbor.deriveSimpleBi ''VssCertData [
+    Cbor.Cons 'VssCertData [
+        Cbor.Field [| lastKnownEoS :: EpochOrSlot                       |],
+        Cbor.Field [| certs        :: VssCertificatesMap                |],
+        Cbor.Field [| whenInsMap   :: HashMap StakeholderId EpochOrSlot |],
+        Cbor.Field [| whenInsSet   :: Set (EpochOrSlot, StakeholderId)  |],
+        Cbor.Field [| whenExpire   :: Set (EpochOrSlot, StakeholderId)  |],
+        Cbor.Field [| expiredCerts :: Set (EpochOrSlot, (StakeholderId,
+                                                      EpochOrSlot,
+                                                      VssCertificate)) |]
+    ]]
+
 deriveSimpleBi ''GtGlobalState [
     Cons 'GtGlobalState [
         Field [| _gsCommitments     :: CommitmentsMap |],
         Field [| _gsOpenings        :: OpeningsMap    |],
         Field [| _gsShares          :: SharesMap      |],
         Field [| _gsVssCertificates :: VssCertData    |]
+    ]]
+
+Cbor.deriveSimpleBi ''GtGlobalState [
+    Cbor.Cons 'GtGlobalState [
+        Cbor.Field [| _gsCommitments     :: CommitmentsMap |],
+        Cbor.Field [| _gsOpenings        :: OpeningsMap    |],
+        Cbor.Field [| _gsShares          :: SharesMap      |],
+        Cbor.Field [| _gsVssCertificates :: VssCertData    |]
     ]]
 
 deriveSimpleBi ''GtSecretStorage [
@@ -41,7 +62,19 @@ deriveSimpleBi ''GtSecretStorage [
         Field [| gssEpoch      :: EpochIndex       |]
     ]]
 
+Cbor.deriveSimpleBi ''GtSecretStorage [
+    Cbor.Cons 'GtSecretStorage [
+        Cbor.Field [| gssCommitment :: SignedCommitment |],
+        Cbor.Field [| gssOpening    :: Opening          |],
+        Cbor.Field [| gssEpoch      :: EpochIndex       |]
+    ]]
+
 deriveSimpleBi ''GenesisGtData [
     Cons 'GenesisGtData [
         Field [| ggdVssCertificates :: VssCertificatesMap |]
+    ]]
+
+Cbor.deriveSimpleBi ''GenesisGtData [
+    Cbor.Cons 'GenesisGtData [
+        Cbor.Field [| ggdVssCertificates :: VssCertificatesMap |]
     ]]

--- a/infra/Pos/Binary/Infra/Relay.hs
+++ b/infra/Pos/Binary/Infra/Relay.hs
@@ -13,9 +13,17 @@ instance Bi key => Bi (InvMsg key) where
     sizeNPut = labelS "InvMsg" $ putField imKey
     get = label "InvMsg" $ InvMsg <$> get
 
+instance Cbor.Bi key => Cbor.Bi (InvMsg key) where
+  encode = Cbor.encode . imKey
+  decode = InvMsg <$> Cbor.decode
+
 instance Bi key => Bi (ReqMsg key) where
     sizeNPut = labelS "ReqMsg" $ putField rmKey
     get = label "ReqMsg" $ ReqMsg <$> get
+
+instance Cbor.Bi key => Cbor.Bi (ReqMsg key) where
+  encode = Cbor.encode . rmKey
+  decode = ReqMsg <$> Cbor.decode
 
 instance Bi (MempoolMsg tag) where
     -- The extra byte is needed because time-warp doesn't work with

--- a/src/Pos/Binary/Block/Block.hs
+++ b/src/Pos/Binary/Block/Block.hs
@@ -5,6 +5,7 @@ module Pos.Binary.Block.Block
        ) where
 
 import           Pos.Binary.Class      (Cons (..), Field (..), deriveSimpleBi)
+import qualified Pos.Binary.Cbor       as Cbor
 import           Pos.Binary.Core       ()
 import           Pos.Binary.Update     ()
 import           Pos.Block.Types       (Undo (..))
@@ -17,4 +18,11 @@ deriveSimpleBi ''Undo [
         Field [| undoTx  :: TxpUndo |],
         Field [| undoPsk :: DlgUndo |],
         Field [| undoUS  :: USUndo  |]
+    ]]
+
+Cbor.deriveSimpleBi ''Undo [
+    Cbor.Cons 'Undo [
+        Cbor.Field [| undoTx  :: TxpUndo |],
+        Cbor.Field [| undoPsk :: DlgUndo |],
+        Cbor.Field [| undoUS  :: USUndo  |]
     ]]

--- a/src/Pos/Binary/Block/Core.hs
+++ b/src/Pos/Binary/Block/Core.hs
@@ -62,11 +62,6 @@ instance Bi (BC.BlockSignature ssc) where
         t -> fail $ "get@BlockSignature: unknown tag: " <> show t
 
 instance Cbor.Bi (BC.BlockSignature ssc) where
-{--
-    = BlockSignature (Signature (MainToSign ssc))
-    | BlockPSignatureLight (ProxySigLight (MainToSign ssc))
-    | BlockPSignatureHeavy (ProxySigHeavy (MainToSign ssc))
---}
   encode input = case input of
     BC.BlockSignature sig       -> Cbor.encodeListLen 2 <> Cbor.encode (0 :: Word8) <> Cbor.encode sig
     BC.BlockPSignatureLight pxy -> Cbor.encodeListLen 2 <> Cbor.encode (1 :: Word8) <> Cbor.encode pxy

--- a/src/Pos/Binary/Block/Core.hs
+++ b/src/Pos/Binary/Block/Core.hs
@@ -10,6 +10,7 @@ import           Pos.Binary.Class             (Bi (..), Cons (..), Field (..),
                                                convertToSizeNPut, deriveSimpleBi,
                                                getWord8, label, labelS, putField, putS,
                                                putWord8S)
+import qualified Pos.Binary.Cbor              as Cbor
 import           Pos.Binary.Core              ()
 import           Pos.Binary.Txp               ()
 import           Pos.Binary.Update            ()
@@ -35,6 +36,19 @@ instance Ssc ssc =>
         putField BC.mpUpdateProof
     get = label "MainProof" $ BC.MainProof <$> get <*> get <*> get <*> get
 
+instance Ssc ssc => Cbor.Bi (Core.BodyProof (BC.MainBlockchain ssc)) where
+  encode bc =  Cbor.encodeListLen 4
+            <> Cbor.encode (BC.mpTxProof bc)
+            <> Cbor.encode (BC.mpMpcProof bc)
+            <> Cbor.encode (BC.mpProxySKsProof bc)
+            <> Cbor.encode (BC.mpUpdateProof bc)
+  decode = do
+    Cbor.enforceSize "Core.BodyProof (BC.MainBlockChain ssc)" 4
+    BC.MainProof <$> Cbor.decode <*>
+                     Cbor.decode <*>
+                     Cbor.decode <*>
+                     Cbor.decode
+
 instance Bi (BC.BlockSignature ssc) where
     sizeNPut = labelS "BlockSignature" $ convertToSizeNPut f
       where
@@ -47,6 +61,25 @@ instance Bi (BC.BlockSignature ssc) where
         2 -> BC.BlockPSignatureHeavy <$> get
         t -> fail $ "get@BlockSignature: unknown tag: " <> show t
 
+instance Cbor.Bi (BC.BlockSignature ssc) where
+{--
+    = BlockSignature (Signature (MainToSign ssc))
+    | BlockPSignatureLight (ProxySigLight (MainToSign ssc))
+    | BlockPSignatureHeavy (ProxySigHeavy (MainToSign ssc))
+--}
+  encode input = case input of
+    BC.BlockSignature sig       -> Cbor.encodeListLen 2 <> Cbor.encode (0 :: Word8) <> Cbor.encode sig
+    BC.BlockPSignatureLight pxy -> Cbor.encodeListLen 2 <> Cbor.encode (1 :: Word8) <> Cbor.encode pxy
+    BC.BlockPSignatureHeavy pxy -> Cbor.encodeListLen 2 <> Cbor.encode (2 :: Word8) <> Cbor.encode pxy
+  decode = do
+    Cbor.enforceSize "BlockSignature" 2
+    tag <- Cbor.decode @Word8
+    case tag of
+      0 -> BC.BlockSignature <$> Cbor.decode
+      1 -> BC.BlockPSignatureLight <$> Cbor.decode
+      2 -> BC.BlockPSignatureHeavy <$> Cbor.decode
+      _ -> fail $ "decode@BlockSignature: unknown tag: " <> show tag
+
 instance Bi (BC.ConsensusData (BC.MainBlockchain ssc)) where
     sizeNPut = labelS "MainConsensusData" $
         putField BC._mcdSlot <>
@@ -54,6 +87,19 @@ instance Bi (BC.ConsensusData (BC.MainBlockchain ssc)) where
         putField BC._mcdDifficulty <>
         putField BC._mcdSignature
     get = label "MainConsensusData" $ BC.MainConsensusData <$> get <*> get <*> get <*> get
+
+instance Cbor.Bi (BC.ConsensusData (BC.MainBlockchain ssc)) where
+  encode cd =  Cbor.encodeListLen 4
+            <> Cbor.encode (BC._mcdSlot cd)
+            <> Cbor.encode (BC._mcdLeaderKey cd)
+            <> Cbor.encode (BC._mcdDifficulty cd)
+            <> Cbor.encode (BC._mcdSignature cd)
+  decode = do
+    Cbor.enforceSize "BC.ConsensusData (BC.MainBlockchain ssc))" 4
+    BC.MainConsensusData <$> Cbor.decode <*>
+                             Cbor.decode <*>
+                             Cbor.decode <*>
+                             Cbor.decode
 
 instance (Ssc ssc) => Bi (BC.Body (BC.MainBlockchain ssc)) where
     sizeNPut = labelS "MainBody" $
@@ -68,6 +114,19 @@ instance (Ssc ssc) => Bi (BC.Body (BC.MainBlockchain ssc)) where
         _mbUpdatePayload <- get
         return BC.MainBody{..}
 
+instance (Ssc ssc) => Cbor.Bi (BC.Body (BC.MainBlockchain ssc)) where
+  encode bc =  Cbor.encodeListLen 4
+            <> Cbor.encode (BC._mbTxPayload  bc)
+            <> Cbor.encode (BC._mbSscPayload bc)
+            <> Cbor.encode (BC._mbDlgPayload bc)
+            <> Cbor.encode (BC._mbUpdatePayload bc)
+  decode = do
+    Cbor.enforceSize "BC.Body (BC.MainBlockchain ssc)" 4
+    BC.MainBody <$> Cbor.decode <*>
+                    Cbor.decode <*>
+                    Cbor.decode <*>
+                    Cbor.decode
+
 deriveSimpleBi ''BC.MainExtraHeaderData [
     Cons 'BC.MainExtraHeaderData [
         Field [| BC._mehBlockVersion    :: BlockVersion              |],
@@ -76,9 +135,22 @@ deriveSimpleBi ''BC.MainExtraHeaderData [
         Field [| BC._mehEBDataProof     :: Hash BC.MainExtraBodyData |]
     ]]
 
+Cbor.deriveSimpleBi ''BC.MainExtraHeaderData [
+    Cbor.Cons 'BC.MainExtraHeaderData [
+        Cbor.Field [| BC._mehBlockVersion    :: BlockVersion              |],
+        Cbor.Field [| BC._mehSoftwareVersion :: SoftwareVersion           |],
+        Cbor.Field [| BC._mehAttributes      :: BC.BlockHeaderAttributes  |],
+        Cbor.Field [| BC._mehEBDataProof     :: Hash BC.MainExtraBodyData |]
+    ]]
+
 deriveSimpleBi ''BC.MainExtraBodyData [
     Cons 'BC.MainExtraBodyData [
         Field [| BC._mebAttributes :: BC.BlockBodyAttributes |]
+    ]]
+
+Cbor.deriveSimpleBi ''BC.MainExtraBodyData [
+    Cbor.Cons 'BC.MainExtraBodyData [
+        Cbor.Field [| BC._mebAttributes :: BC.BlockBodyAttributes |]
     ]]
 
 instance Ssc ssc => Bi (BC.MainToSign ssc) where
@@ -90,6 +162,21 @@ instance Ssc ssc => Bi (BC.MainToSign ssc) where
         putField BC._msExtraHeader
     get = label "MainToSign" $ BC.MainToSign <$> get <*> get <*> get <*> get <*> get
 
+instance Ssc ssc => Cbor.Bi (BC.MainToSign ssc) where
+  encode mts = Cbor.encodeListLen 5
+             <> Cbor.encode (BC._msHeaderHash mts)
+             <> Cbor.encode (BC._msBodyProof mts)
+             <> Cbor.encode (BC._msSlot mts)
+             <> Cbor.encode (BC._msChainDiff mts)
+             <> Cbor.encode (BC._msExtraHeader mts)
+  decode = do
+    Cbor.enforceSize "BC.MainToSign" 5
+    BC.MainToSign <$> Cbor.decode <*>
+                      Cbor.decode <*>
+                      Cbor.decode <*>
+                      Cbor.decode <*>
+                      Cbor.decode
+
 -- ----------------------------------------------------------------------------
 -- -- GenesisBlock
 -- ----------------------------------------------------------------------------
@@ -99,14 +186,28 @@ deriveSimpleBi ''BC.GenesisExtraHeaderData [
         Field [| BC._gehAttributes :: BC.GenesisHeaderAttributes |]
     ]]
 
+Cbor.deriveSimpleBi ''BC.GenesisExtraHeaderData [
+    Cbor.Cons 'BC.GenesisExtraHeaderData [
+        Cbor.Field [| BC._gehAttributes :: BC.GenesisHeaderAttributes |]
+    ]]
+
 deriveSimpleBi ''BC.GenesisExtraBodyData [
     Cons 'BC.GenesisExtraBodyData [
         Field [| BC._gebAttributes :: BC.GenesisBodyAttributes |]
     ]]
 
+Cbor.deriveSimpleBi ''BC.GenesisExtraBodyData [
+    Cbor.Cons 'BC.GenesisExtraBodyData [
+        Cbor.Field [| BC._gebAttributes :: BC.GenesisBodyAttributes |]
+    ]]
+
 instance Bi (BC.BodyProof (BC.GenesisBlockchain ssc)) where
     sizeNPut = labelS "GenesisProof" $ putField (\(BC.GenesisProof h) -> h)
     get = label "GenesisProof" $ BC.GenesisProof <$> get
+
+instance Cbor.Bi (BC.BodyProof (BC.GenesisBlockchain ssc)) where
+  encode (BC.GenesisProof h) = Cbor.encode h
+  decode = BC.GenesisProof <$> Cbor.decode
 
 instance Bi (BC.ConsensusData (BC.GenesisBlockchain ssc)) where
     sizeNPut = labelS "GenesisConsensusData" $
@@ -114,6 +215,18 @@ instance Bi (BC.ConsensusData (BC.GenesisBlockchain ssc)) where
         putField BC._gcdDifficulty
     get = label "GenesisConsensusData" $ BC.GenesisConsensusData <$> get <*> get
 
+instance Cbor.Bi (BC.ConsensusData (BC.GenesisBlockchain ssc)) where
+  encode bc =  Cbor.encodeListLen 2
+            <> Cbor.encode (BC._gcdEpoch bc)
+            <> Cbor.encode (BC._gcdDifficulty bc)
+  decode = do
+    Cbor.enforceSize "BC.ConsensusData (BC.GenesisBlockchain ssc)" 2
+    BC.GenesisConsensusData <$> Cbor.decode <*> Cbor.decode
+
 instance Bi (BC.Body (BC.GenesisBlockchain ssc)) where
     sizeNPut = labelS "GenesisBody" $ putField BC._gbLeaders
     get = label "GenesisBody" $ BC.GenesisBody <$> get
+
+instance Cbor.Bi (BC.Body (BC.GenesisBlockchain ssc)) where
+  encode = Cbor.encode . BC._gbLeaders
+  decode = BC.GenesisBody <$> Cbor.decode

--- a/src/Pos/Binary/Communication.hs
+++ b/src/Pos/Binary/Communication.hs
@@ -66,9 +66,17 @@ instance SscHelpersClass ssc => Bi (MsgHeaders ssc) where
     sizeNPut = labelS "MsgHeaders" $ putField $ \(MsgHeaders b) -> b
     get = label "MsgHeaders" $ MsgHeaders <$> get
 
+instance SscHelpersClass ssc => Cbor.Bi (MsgHeaders ssc) where
+  encode (MsgHeaders b) = Cbor.encode b
+  decode = MsgHeaders <$> Cbor.decode
+
 instance SscHelpersClass ssc => Bi (MsgBlock ssc) where
     sizeNPut = labelS "MsgBlock" $ putField $ \(MsgBlock b) -> b
     get = label "MsgBlock" $ MsgBlock <$> get
+
+instance SscHelpersClass ssc => Cbor.Bi (MsgBlock ssc) where
+  encode (MsgBlock b) = Cbor.encode b
+  decode = MsgBlock <$> Cbor.decode
 
 ----------------------------------------------------------------------------
 -- Protocol version info and related

--- a/src/Pos/Binary/Explorer.hs
+++ b/src/Pos/Binary/Explorer.hs
@@ -5,6 +5,7 @@ module Pos.Binary.Explorer () where
 import           Universum
 
 import           Pos.Binary.Class        (Cons (..), Field (..), deriveSimpleBi)
+import qualified Pos.Binary.Cbor         as Cbor
 import           Pos.Binary.Txp          ()
 import           Pos.Core                (HeaderHash, Timestamp)
 import           Pos.Explorer.Core.Types (TxExtra (..))
@@ -15,4 +16,11 @@ deriveSimpleBi ''TxExtra [
         Field [| teBlockchainPlace :: Maybe (HeaderHash, Word32) |],
         Field [| teReceivedTime    :: Timestamp                  |],
         Field [| teInputOutputs    :: NonEmpty TxOutAux          |]
+    ]]
+
+Cbor.deriveSimpleBi ''TxExtra [
+    Cbor.Cons 'TxExtra [
+        Cbor.Field [| teBlockchainPlace :: Maybe (HeaderHash, Word32) |],
+        Cbor.Field [| teReceivedTime    :: Timestamp                  |],
+        Cbor.Field [| teInputOutputs    :: NonEmpty TxOutAux          |]
     ]]

--- a/ssc/Pos/Ssc/Class/Types.hs
+++ b/ssc/Pos/Ssc/Class/Types.hs
@@ -14,6 +14,7 @@ import           Data.Text.Buildable (Buildable)
 import           Universum
 
 import           Pos.Binary.Class    (Bi)
+import qualified Pos.Binary.Cbor     as Cbor
 import           Pos.Core            (HasDifficulty (..), HasEpochIndex (..),
                                       HasEpochOrSlot (..), HasHeaderHash (..),
                                       IsGenesisHeader, IsMainHeader)
@@ -35,6 +36,8 @@ class ( Typeable ssc
       , Buildable (SscGlobalState ssc)
       , Bi (SscProof ssc)
       , Bi (SscPayload ssc)
+      , Cbor.Bi (SscProof ssc)
+      , Cbor.Bi (SscPayload ssc)
       , NFData (SscPayload ssc)
       , NFData (SscProof ssc)
       ) =>

--- a/test/Test/Pos/CborSpec.hs
+++ b/test/Test/Pos/CborSpec.hs
@@ -1,0 +1,80 @@
+
+-- | Pos.Crypto specification
+
+module Test.Pos.CborSpec
+       ( spec
+       ) where
+
+import qualified Codec.CBOR.FlatTerm as CBOR
+import           Pos.Binary.Cbor
+import           Pos.Binary.Class.Numbers
+import           Pos.Binary.Core.Fee ()
+import           Pos.Binary.Core.Script ()
+import           Pos.Core.Arbitrary ()
+import           Pos.Core.Fee
+import           Pos.Core.Genesis.Types
+import           Pos.Core.Types
+import           Test.QuickCheck
+import           Universum
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
+
+-- Machinery to test we perform "flat" encoding.
+hasValidFlatTerm :: Bi a => a -> Bool
+hasValidFlatTerm = CBOR.validFlatTerm . CBOR.toFlatTerm . encode
+
+-- | Given a data type which can be generated randomly and for which the CBOR
+-- encoding is defined, generates the roundtrip tests.
+roundtripProperty :: (Arbitrary a, Eq a, Show a, Bi a) => a -> Property
+roundtripProperty (input :: a) = ((deserialize . serialize $ input) :: a) === input
+
+-- | Given a data type which can be extended, verify we can indeed do so
+-- without breaking anything. This should work with every time which adopted
+-- the schema of having at least one constructor of the form:
+-- .... | Unknown Word8 ByteString
+extensionProperty :: (Arbitrary a, Eq a, Show a, Bi a) => Proxy a -> Property
+extensionProperty (Proxy :: Proxy a) = forAll (arbitrary :: Gen a) $ \input ->
+  let serialized      = serialize input -- We now have a BS blob
+      (u :: U)        = deserialize serialized
+      (encoded :: a)  = deserialize (serialize u)
+  in encoded === input
+
+soundInstanceProperty :: (Arbitrary a, Eq a, Show a, Bi a) => Proxy a -> Property
+soundInstanceProperty (Proxy :: Proxy a) = forAll (arbitrary :: Gen a) $ \input ->
+  let itRoundtrips = roundtripProperty input
+      isFlat       = hasValidFlatTerm input === True
+  in itRoundtrips .&&. isFlat
+
+spec = describe "Cbor Specs" $ do
+         prop "Cbor.Bi" (soundInstanceProperty @(UnsignedVarInt Int) Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @(SignedVarInt Int) Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @(FixedSizeInt Int) Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @(UnsignedVarInt Int64) Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @(SignedVarInt Int64) Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @(FixedSizeInt Int64) Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @(UnsignedVarInt Word) Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @(FixedSizeInt Word) Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @(UnsignedVarInt Word16) Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @(UnsignedVarInt Word32) Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @(UnsignedVarInt Word64) Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @TinyVarInt Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @Int64 Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @MyScript Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @Coeff Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @TxSizeLinear Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @TxFeePolicy Proxy .&&. extensionProperty @TxFeePolicy Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @Script Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @Timestamp Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @EpochIndex Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @Coin Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @CoinPortion Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @LocalSlotIndex Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @SlotId Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @EpochOrSlot Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @SharedSeed Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @ChainDifficulty Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @StakeDistribution Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @ApplicationName Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @SoftwareVersion Proxy)
+         prop "Cbor.Bi" (soundInstanceProperty @BlockVersion Proxy)

--- a/test/Test/Pos/CborSpec.hs
+++ b/test/Test/Pos/CborSpec.hs
@@ -1,5 +1,11 @@
 
--- | Pos.Crypto specification
+-- | Test.Pos.CborSpec specification
+
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Test.Pos.CborSpec
        ( spec
@@ -14,11 +20,84 @@ import           Pos.Core.Arbitrary ()
 import           Pos.Core.Fee
 import           Pos.Core.Genesis.Types
 import           Pos.Core.Types
+import           Test.Hspec (Expectation, Spec, describe)
 import           Test.QuickCheck
 import           Universum
 
+import qualified Codec.CBOR.FlatTerm as CBOR
+import           Pos.Binary.Cbor
+import           Test.Hspec.QuickCheck (prop)
+
+import           Universum
+import           Test.QuickCheck
+import           Test.QuickCheck.Arbitrary.Generic (genericArbitrary, genericShrink)
+import           Pos.Core.Fee
+import           Pos.Binary.Core.Fee ()
+import           Pos.Core.Arbitrary ()
+import           Pos.Binary.Core.Script ()
+import           Pos.Core.Types
+import           Pos.Core.Genesis.Types
+import           Pos.Binary.Class.Numbers
+import           Pos.Data.Attributes
+
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Map as M
+
+data MyScript = MyScript
+    { version :: ScriptVersion -- ^ Version
+    , script  :: LByteString   -- ^ Serialized script
+    } deriving (Eq, Show, Generic, Typeable)
+
+instance Arbitrary MyScript where
+  arbitrary = MyScript <$> arbitrary <*> arbitrary
+
+deriveSimpleBi ''MyScript [
+    Cons 'MyScript [
+        Field [| version :: ScriptVersion |],
+        Field [| script  :: LByteString   |]
+    ]]
+
+-- Type to be used to simulate a breaking change in the serialisation
+-- schema, so we can test instances which uses the `UnknownXX` pattern
+-- for extensibility.
+data U = U Word8 BS.ByteString
+
+instance Bi U where
+  encode (U word8 bs) = encodeListLen 2 <> encode (word8 :: Word8) <> encode bs
+  decode = do
+    decodeListLenOf 2
+    U <$> decode <*> decode
+
+----------------------------------------
+
+data X1 = X1 { x1A :: Int }
+    deriving (Eq, Ord, Show, Generic)
+
+data X2 = X2 { x2A :: Int, x2B :: String }
+    deriving (Eq, Ord, Show, Generic)
+
+instance Arbitrary X1 where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
+instance Arbitrary X2 where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
+instance Bi (Attributes X1) where
+    encode = encodeAttributes [(0, serialize' . x1A)]
+    decode = decodeAttributes (X1 0) $ \n v acc -> case n of
+        0 -> Just $ acc { x1A = deserialize' v }
+        _ -> Nothing
+
+instance Bi (Attributes X2) where
+    encode = encodeAttributes [(0, serialize' . x2A), (1, serialize' . x2B)]
+    decode = decodeAttributes (X2 0 []) $ \n v acc -> case n of
+        0 -> Just $ acc { x2A = deserialize' v }
+        1 -> Just $ acc { x2B = deserialize' v }
+        _ -> Nothing
+
+----------------------------------------
 
 -- Machinery to test we perform "flat" encoding.
 hasValidFlatTerm :: Bi a => a -> Bool
@@ -40,41 +119,119 @@ extensionProperty (Proxy :: Proxy a) = forAll (arbitrary :: Gen a) $ \input ->
       (encoded :: a)  = deserialize (serialize u)
   in encoded === input
 
+soundSerializationAttributesOfAsProperty
+    :: forall a b aa ab. (aa ~ Attributes a, ab ~ Attributes b,
+                          Bi aa, Bi ab, Eq aa, Arbitrary a, Show aa)
+    => Proxy a
+    -> Proxy b
+    -> Property
+soundSerializationAttributesOfAsProperty _ _ = forAll arbitraryAttrs $ \input ->
+    let serialized      = serialize input
+        (middle  :: ab) = deserialize serialized
+        (encoded :: aa) = deserialize $ serialize middle
+    in encoded === input
+    where
+      arbitraryAttrs :: Gen aa
+      arbitraryAttrs = Attributes <$> arbitrary <*> arbitraryUnparsedFields
+
+-- TODO: Use as a main Arbitrary instance for UnparsedFields after transition to
+-- CBOR.
+arbitraryUnparsedFields :: Gen UnparsedFields
+arbitraryUnparsedFields = sized $ go M.empty
+  where
+    go !acc 0 = pure $ UnparsedFields acc
+    go !acc n = do
+        -- Assume that data type doesn't have more than 100 constructors.
+        k <- choose (100, maxBound)
+        v <- arbitrary
+        go (M.insert k v acc) (n - 1)
+
 soundInstanceProperty :: (Arbitrary a, Eq a, Show a, Bi a) => Proxy a -> Property
 soundInstanceProperty (Proxy :: Proxy a) = forAll (arbitrary :: Gen a) $ \input ->
   let itRoundtrips = roundtripProperty input
       isFlat       = hasValidFlatTerm input === True
   in itRoundtrips .&&. isFlat
 
-spec = describe "Cbor Specs" $ do
-         prop "Cbor.Bi" (soundInstanceProperty @(UnsignedVarInt Int) Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @(SignedVarInt Int) Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @(FixedSizeInt Int) Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @(UnsignedVarInt Int64) Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @(SignedVarInt Int64) Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @(FixedSizeInt Int64) Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @(UnsignedVarInt Word) Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @(FixedSizeInt Word) Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @(UnsignedVarInt Word16) Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @(UnsignedVarInt Word32) Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @(UnsignedVarInt Word64) Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @TinyVarInt Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @Int64 Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @MyScript Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @Coeff Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @TxSizeLinear Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @TxFeePolicy Proxy .&&. extensionProperty @TxFeePolicy Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @Script Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @Timestamp Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @EpochIndex Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @Coin Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @CoinPortion Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @LocalSlotIndex Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @SlotId Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @EpochOrSlot Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @SharedSeed Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @ChainDifficulty Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @StakeDistribution Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @ApplicationName Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @SoftwareVersion Proxy)
-         prop "Cbor.Bi" (soundInstanceProperty @BlockVersion Proxy)
+spec :: Spec
+spec = describe "Cbor.Bi instances" $ do
+    prop "UnsignedVarInt" (soundInstanceProperty @(UnsignedVarInt Int) Proxy)
+    prop "SignedVarInt" (soundInstanceProperty @(SignedVarInt Int) Proxy)
+    prop "FixedSizeInt" (soundInstanceProperty @(FixedSizeInt Int) Proxy)
+    prop "UnsignedVarInt" (soundInstanceProperty @(UnsignedVarInt Int64) Proxy)
+    prop "SignedVarInt" (soundInstanceProperty @(SignedVarInt Int64) Proxy)
+    prop "FixedSizeInt" (soundInstanceProperty @(FixedSizeInt Int64) Proxy)
+    prop "UnsignedVarInt" (soundInstanceProperty @(UnsignedVarInt Word) Proxy)
+    prop "FixedSizeInt" (soundInstanceProperty @(FixedSizeInt Word) Proxy)
+    prop "UnsignedVarInt" (soundInstanceProperty @(UnsignedVarInt Word16) Proxy)
+    prop "UnsignedVarInt" (soundInstanceProperty @(UnsignedVarInt Word32) Proxy)
+    prop "UnsignedVarInt" (soundInstanceProperty @(UnsignedVarInt Word64) Proxy)
+    prop "TinyVarInt" (soundInstanceProperty @TinyVarInt Proxy)
+    prop "Int64" (soundInstanceProperty @Int64 Proxy)
+    prop "MyScript" (soundInstanceProperty @MyScript Proxy)
+    prop "Coeff" (soundInstanceProperty @Coeff Proxy)
+    prop "TxSizeLinear" (soundInstanceProperty @TxSizeLinear Proxy)
+    prop "TxFeePolicy" (soundInstanceProperty @TxFeePolicy Proxy .&&. extensionProperty @TxFeePolicy Proxy)
+    prop "Script" (soundInstanceProperty @Script Proxy)
+    prop "Timestamp" (soundInstanceProperty @Timestamp Proxy)
+    prop "EpochIndex" (soundInstanceProperty @EpochIndex Proxy)
+    prop "Attributes" (soundInstanceProperty @(Attributes ()) Proxy)
+    prop "Coin" (soundInstanceProperty @Coin Proxy)
+    prop "CoinPortion" (soundInstanceProperty @CoinPortion Proxy)
+    prop "LocalSlotIndex" (soundInstanceProperty @LocalSlotIndex Proxy)
+    prop "SlotId" (soundInstanceProperty @SlotId Proxy)
+    prop "EpochOrSlot" (soundInstanceProperty @EpochOrSlot Proxy)
+    prop "SharedSeed" (soundInstanceProperty @SharedSeed Proxy)
+    prop "ChainDifficulty" (soundInstanceProperty @ChainDifficulty Proxy)
+    prop "StakeDistribution" (soundInstanceProperty @StakeDistribution Proxy)
+    prop "ApplicationName" (soundInstanceProperty @ApplicationName Proxy)
+    prop "SoftwareVersion" (soundInstanceProperty @SoftwareVersion Proxy)
+    prop "BlockVersion" (soundInstanceProperty @BlockVersion Proxy)
+    prop "Attributes" (soundInstanceProperty @(Attributes X1) Proxy)
+    prop "Attributes" (soundInstanceProperty @(Attributes X2) Proxy)
+    prop "X2" (soundSerializationAttributesOfAsProperty @X2 @X1 Proxy Proxy)
+
+----------------------------------------
+
+data User
+    = Login {
+      login :: String
+    , age   :: Int
+    }
+    | FullName {
+      firstName  :: String
+    , lastName   :: String
+    , sex        :: Bool
+    } deriving Show
+
+deriveSimpleBi ''User [
+    Cons 'Login [
+        Field [| login :: String |],
+        Field [| age   :: Int    |]
+    ],
+    Cons 'FullName [
+        Field [| firstName :: String |],
+        Field [| lastName  :: String |],
+        Field [| sex       :: Bool   |]
+    ]]
+
+u1 :: User
+u1 = deserialize $ serialize $ Login "asd" 34
+
+----------------------------------------
+
+data T = T1 Int | T2 Int Int | Unknown Word8 BS.ByteString
+    deriving Show
+
+instance Bi T where
+    encode = \case
+        T1 a         -> encode (0::Word8)
+                     <> encode (serialize' a)
+        T2 a b       -> encode (1::Word8)
+                     <> encode (serialize' (a, b))
+        Unknown n bs -> encode n
+                     <> encode bs
+
+    decode = decode @Word8 >>= \case
+        0 ->         T1 . deserialize' <$> decode
+        1 -> uncurry T2 . deserialize' <$> decode
+        t -> Unknown t                 <$> decode

--- a/test/Test/Pos/CborSpec.hs
+++ b/test/Test/Pos/CborSpec.hs
@@ -13,6 +13,7 @@ module Test.Pos.CborSpec
 
 import qualified Codec.CBOR.FlatTerm as CBOR
 import           Pos.Binary.Cbor
+import           Pos.Binary.Class (AsBinary (..))
 import           Pos.Binary.Class.Numbers
 import           Pos.Binary.Core.Fee ()
 import           Pos.Binary.Core.Script ()
@@ -21,7 +22,11 @@ import           Pos.Core.Arbitrary ()
 import           Pos.Core.Fee
 import           Pos.Core.Genesis.Types
 import           Pos.Core.Types
+import           Pos.Crypto.HD (HDAddressPayload)
+import           Pos.Crypto.RedeemSigning (RedeemPublicKey, RedeemSecretKey)
+import           Pos.Crypto.SafeSigning (PassPhrase)
 import           Pos.Crypto.SecretSharing (VssPublicKey, VssKeyPair, Secret, Share, EncShare, SecretProof)
+import           Pos.Crypto.Signing (PublicKey, SecretKey)
 import           Test.Hspec (Spec, describe, it, pendingWith)
 import           Test.QuickCheck
 import           Universum
@@ -193,7 +198,24 @@ spec = describe "Cbor.Bi instances" $ do
         prop "Share" (soundInstanceProperty @Share Proxy)
         prop "EncShare" (soundInstanceProperty @EncShare Proxy)
         prop "SecretProof" (soundInstanceProperty @SecretProof Proxy)
+        prop "AsBinary VssPublicKey" (soundInstanceProperty @(AsBinary VssPublicKey) Proxy)
+        prop "AsBinary Secret" (soundInstanceProperty @(AsBinary Secret) Proxy)
+        prop "AsBinary Share" (soundInstanceProperty @(AsBinary Share) Proxy)
+        prop "AsBinary EncShare" (soundInstanceProperty @(AsBinary EncShare) Proxy)
+        prop "AsBinary SecretProof" (soundInstanceProperty @(AsBinary SecretProof) Proxy)
+        prop "CC.ChainCode" (soundInstanceProperty @(AsBinary SecretProof) Proxy)
+        prop "PublicKey" (soundInstanceProperty @PublicKey Proxy)
+        prop "SecretKey" (soundInstanceProperty @SecretKey Proxy)
+        prop "PassPhrase" (soundInstanceProperty @PassPhrase Proxy)
+        prop "HDAddressPayload" (soundInstanceProperty @HDAddressPayload Proxy)
+        prop "RedeemPublicKey" (soundInstanceProperty @RedeemPublicKey Proxy)
+        prop "RedeemSecretKey" (soundInstanceProperty @RedeemSecretKey Proxy)
         -- Pending specs
+        it "(Signature a)"        $ pendingWith "Arbitrary instance requires Bi (not Cbor.Bi) constraint"
+        it "(Signed a)"           $ pendingWith "Arbitrary instance requires Bi (not Cbor.Bi) constraint"
+        it "(RedeemSignature a)"  $ pendingWith "Arbitrary instance requires Bi (not Cbor.Bi) constraint"
+        it "(ProxySecretKey w)"   $ pendingWith "Arbitrary instance requires Bi (not Cbor.Bi) constraint"
+        it "(ProxySignature w a)" $ pendingWith "Arbitrary instance requires Bi (not Cbor.Bi) constraint"
         it "AbstractHash SHA256"  $ pendingWith "Arbitrary instance requires Bi (not Cbor.Bi) constraint"
         it "SecretSharingExtra"   $ pendingWith "Requires proper implementation"
         it "Address"              $ pendingWith "Requires proper implementation"
@@ -205,6 +227,18 @@ spec = describe "Cbor.Bi instances" $ do
         pendingNoArbitrary "Pvss.DecryptedShare"
         pendingNoArbitrary "Pvss.EncryptedShare"
         pendingNoArbitrary "Pvss.Proof"
+        pendingNoArbitrary "AsBinary VssKeyPair"
+        pendingNoArbitrary "Ed25519.PointCompressed"
+        pendingNoArbitrary "Ed25519.Scalar"
+        pendingNoArbitrary "Ed25519.Signature"
+        pendingNoArbitrary "CC.ChainCode"
+        pendingNoArbitrary "CC.XPub"
+        pendingNoArbitrary "CC.XPrv"
+        pendingNoArbitrary "CC.XSignature"
+        pendingNoArbitrary "EdStandard.PublicKey"
+        pendingNoArbitrary "EdStandard.SecretKey"
+        pendingNoArbitrary "EdStandard.Signature"
+        pendingNoArbitrary "EncryptedSecretKey"
 
 pendingNoArbitrary :: String -> Spec
 pendingNoArbitrary ty = it ty $ pendingWith "Arbitrary instance required"


### PR DESCRIPTION
Dumping here some more instances.

It's not necessary to merge this straight away, it's mostly useful for me for bookkeeping purposes 😉 

Instances included in this PR:

- [x] (BodyProof (MainBlockchain ssc)) 
- [x] (BlockSignature ssc) 
- [x] (ConsensusData (MainBlockchain ssc)) 
- [x] (Body (MainBlockchain ssc)) 
- [x] MainExtraHeaderData 
- [x] MainExtraBodyData 
- [x] (MainToSign ssc) 
- [x] GenesisExtraHeaderData 
- [x] GenesisExtraBodyData 
- [x] (BodyProof (GenesisBlockchain ssc)) 
- [x] (ConsensusData (GenesisBlockchain ssc)) 
- [x] (Body (GenesisBlockchain ssc))
- [x] BlockHeaderStub
- [x] (GenericBlockHeader b)
- [x] (GenericBlock b)
- [x] Int64
- [x] (UnsignedVarInt Int)
- [x] (SignedVarInt Int)
- [x] (FixedSizeInt Int)
- [x] (UnsignedVarInt Int64)
- [x] (SignedVarInt Int64)
- [x] (FixedSizeInt Int64)
- [x] (UnsignedVarInt Word)
- [x] (FixedSizeInt Word)
- [x] (UnsignedVarInt Word16)
- [x] (UnsignedVarInt Word32)
- [x] (UnsignedVarInt Word64)
- [x] TinyVarInt
- [x] GtTag
- [x] TossModifier
- [x] VssCertData
- [x] GtGlobalState
- [x] GtSecretStorage
- [x] GenesisGtData
- [x] InvMsg key
- [x] ReqMsg key
- [x] NewestFirst
- [x] OldestFirst
- [x] Undo
- [x] (MsgHeaders ssc)
- [x] (MsgBlock ssc)
- [x] TxExtra

@arybczak I have re-run `ag` for sanity check and I'm fairly confident ( 🤞 ) this last PR ports all the remaining instances (modulo the ones stubbed/in-the-works, on top of my mind `Address`, `Attributes` and `SecretSharingExtra`).

I guess the next major step would be to tackle testing.